### PR TITLE
Resolve: "Open Subgraphs in the same viewer but in a nested level"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,11 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/connectionui.h
     intelli/gui/grapheditor.h
     intelli/gui/graphscene.h
+    intelli/gui/graphscenemanager.h
+    intelli/gui/graphsceneselector.h
+    intelli/gui/graphstatemanager.h
     intelli/gui/graphview.h
+    intelli/gui/graphviewoverlay.h
     intelli/gui/packageui.h
     intelli/gui/graphics/connectionobject.h
     intelli/gui/graphics/nodeevalstateobject.h
@@ -181,7 +185,11 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/nodeui.cpp
     intelli/gui/grapheditor.cpp
     intelli/gui/graphscene.cpp
+    intelli/gui/graphscenemanager.cpp
+    intelli/gui/graphsceneselector.cpp
+    intelli/gui/graphstatemanager.cpp
     intelli/gui/graphview.cpp
+    intelli/gui/graphviewoverlay.cpp
     intelli/gui/icons.cpp
     intelli/gui/packageui.cpp
     intelli/gui/style.cpp

--- a/src/intelli/data/object.cpp
+++ b/src/intelli/data/object.cpp
@@ -13,7 +13,7 @@ using namespace intelli;
 
 ObjectData::ObjectData(GtObject const* obj) :
     NodeData(QStringLiteral("object")),
-    m_obj(volatile_ptr<GtObject, DeferredDeleter>(obj ? obj->clone() : nullptr))
+    m_obj(unique_qptr<GtObject, DeferredDeleter>(obj ? obj->clone() : nullptr))
 {
 
 }

--- a/src/intelli/data/object.h
+++ b/src/intelli/data/object.h
@@ -40,8 +40,8 @@ public:
     Q_INVOKABLE GtObject const* object() const { return m_obj.get(); }
 
 private:
-
-    volatile_ptr<GtObject, DeferredDeleter> m_obj;
+    
+    unique_qptr<GtObject, DeferredDeleter> m_obj;
 };
 
 } // namespace intelli

--- a/src/intelli/future.cpp
+++ b/src/intelli/future.cpp
@@ -39,6 +39,9 @@ struct ExecFuture::Impl
         QObject::connect(future.m_model, &GraphExecutionModel::nodeEvaluationFailed,
                          &loop, performUpdate);
 
+        // loop failed
+        if (future.m_targets.empty()) return emit loop.failed();
+
         performUpdate();
     }
 

--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -170,16 +170,14 @@ GraphExecutionModel::setupConnections(Graph& graph)
         onNodeDeleted(g, nodeId);
     }, Qt::DirectConnection);
 
-    if (&this->graph() == &graph)
-    {
-        connect(&graph, &Graph::globalConnectionAppended,
-                this, &GraphExecutionModel::onConnectionAppended,
-                Qt::DirectConnection);
-        connect(&graph, &Graph::globalConnectionDeleted,
-                this, &GraphExecutionModel::onConnectionDeleted,
-                Qt::DirectConnection);
-    }
-    connect(&graph, &Graph::nodePortInserted,
+    connect(&graph, &Graph::globalConnectionAppended,
+            this, &GraphExecutionModel::onConnectionAppended,
+            Qt::DirectConnection);
+    connect(&graph, &Graph::globalConnectionDeleted,
+            this, &GraphExecutionModel::onConnectionDeleted,
+            Qt::DirectConnection);
+
+        connect(&graph, &Graph::nodePortInserted,
             this, &GraphExecutionModel::onNodePortInserted,
             Qt::DirectConnection);
     connect(&graph, &Graph::nodePortAboutToBeDeleted,

--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -127,6 +127,20 @@ GraphExecutionModel::accessExecModel(const Graph& graph)
     return accessExecModel(const_cast<Graph&>(graph));
 }
 
+GraphExecutionModel*
+GraphExecutionModel::make(Graph& graph)
+{
+    auto* root = &graph;
+    assert(root);
+
+    auto* model = accessExecModel(*root);
+    if (!model)
+    {
+        model = new GraphExecutionModel(*root);
+    }
+    return model;
+}
+
 Graph&
 GraphExecutionModel::graph()
 {
@@ -372,6 +386,8 @@ GraphExecutionModel::stopAutoEvaluatingGraph(Graph& graph)
     assert(Impl::containsGraph(*this, graph));
 
     utils::erase(m_autoEvaluatingGraphs, graph.uuid());
+
+    emit autoEvaluationChanged(&graph);
 
     if (Impl::rescheduleAutoEvaluatingNodes(*this))
     {

--- a/src/intelli/graphexecmodel.h
+++ b/src/intelli/graphexecmodel.h
@@ -50,6 +50,16 @@ public:
     static GraphExecutionModel const* accessExecModel(Graph const& graph);
 
     /**
+     * @brief Creates and appends a execution model to the graph hierarchy of
+     * `graph` and returns a pointer to the newely created exec model. The
+     * ownership is taken care of. If a exec model already exists for `graph`,
+     * it is returned instead.
+     * @param graph Graph to create and append exec model for.
+     * @return Pointer to current exec model.
+     */
+    static GraphExecutionModel* make(Graph& graph);
+
+    /**
      * @brief Provides access to the current graph
      * @return The associated graph of the model
      */
@@ -313,6 +323,8 @@ signals:
      * could not be evalauted due to cross dependencies to other exec models
      */
     void wakeup(QPrivateSignal);
+
+    void autoEvaluationChanged(Graph* graph);
 
 private:
 

--- a/src/intelli/graphexecmodel.h
+++ b/src/intelli/graphexecmodel.h
@@ -324,6 +324,10 @@ signals:
      */
     void wakeup(QPrivateSignal);
 
+    /**
+     * @brief Emiited once the auto evalaution state of `graph` has changed.
+     * @param graph Graph that has changed its auto evaluation state.
+     */
     void autoEvaluationChanged(Graph* graph);
 
 private:

--- a/src/intelli/gui/grapheditor.cpp
+++ b/src/intelli/gui/grapheditor.cpp
@@ -121,5 +121,7 @@ GraphEditor::initialized()
     m_sceneManager = GraphSceneManager::make(*m_view);
 
     m_overlay = GraphViewOverlay::make(*m_view);
-    Q_UNUSED(m_overlay);
+    
+    connect(m_overlay, &GraphViewOverlay::sceneChangeRequested,
+            m_sceneManager, &GraphSceneManager::openGraphByUuid);
 }

--- a/src/intelli/gui/grapheditor.cpp
+++ b/src/intelli/gui/grapheditor.cpp
@@ -10,15 +10,22 @@
 #include "intelli/gui/grapheditor.h"
 
 #include <intelli/graph.h>
+#include <intelli/graphexecmodel.h>
 #include <intelli/gui/graphscene.h>
+#include <intelli/gui/graphscenemanager.h>
+#include <intelli/gui/graphstatemanager.h>
 #include <intelli/gui/graphview.h>
+#include <intelli/gui/graphviewoverlay.h>
 #include <intelli/gui/style.h>
+#include <intelli/private/utils.h>
 
 #include <gt_logging.h>
 
 #include <gt_application.h>
+#include <gt_icons.h>
 
 #include <QVBoxLayout>
+#include <QPushButton>
 
 /*
  * generated 1.2.0
@@ -61,28 +68,38 @@ void
 GraphEditor::setData(GtObject* obj)
 {
     assert(m_view);
+    assert(m_sceneManager);
 
-    auto graph  = qobject_cast<Graph*>(obj);
+    auto* graph  = qobject_cast<Graph*>(obj);
     if (!graph)
     {
         gtError().verbose() << tr("Not an intelli graph!") << obj;
         return;
     }
 
-    if (m_scene)
+    // setup exec model
+    auto* model = GraphExecutionModel::make(*graph);
+    if (!model)
     {
-        gtError().verbose()
-            << tr("Expected null intelli graph scene, aborting!");
+        gtError()
+            << tr("Failed to create exec model for graph '%1'!")
+                   .arg(relativeNodePath(*graph));
         return;
     }
+    model->reset();
 
-    // instantly commit suicide if widget is destroyed (avoids issue #87)
-    connect(graph, &QObject::destroyed, this, [this](){ delete this; });
+    // setup state manager
+    GraphStateManager::make(*graph, *m_view);
 
-    // close graph model if its no longer used
-    m_scene = make_volatile<GraphScene, DirectDeleter>(*graph);
-
-    m_view->setScene(*m_scene);
+    // create initial scene
+    auto* scene = m_sceneManager->createScene(*graph);
+    if (!scene)
+    {
+        gtError().verbose()
+            << tr("Failed to create scene for graph '%1'!")
+                   .arg(relativeNodePath(*graph));
+        return;
+    }
 
     setObjectName(tr("IntelliGraph Editor") + QStringLiteral(" - ") + graph->caption());
 }
@@ -91,10 +108,18 @@ void
 GraphEditor::initialized()
 {
     assert(!m_view);
+    assert(!m_sceneManager);
+    assert(!m_overlay);
+
     m_view = new GraphView;
     m_view->setFrameShape(QFrame::NoFrame);
 
     auto* l = new QVBoxLayout(widget());
     l->addWidget(m_view);
     l->setContentsMargins(0, 0, 0, 0);
+
+    m_sceneManager = GraphSceneManager::make(*m_view);
+
+    m_overlay = GraphViewOverlay::make(*m_view);
+    Q_UNUSED(m_overlay);
 }

--- a/src/intelli/gui/grapheditor.h
+++ b/src/intelli/gui/grapheditor.h
@@ -20,7 +20,9 @@ namespace intelli
 {
 
 class GraphScene;
+class GraphSceneManager;
 class GraphView;
+class GraphViewOverlay;
 
 /**
  * @generated 1.2.0
@@ -43,10 +45,12 @@ protected:
 
 private:
 
-    /// scene
-    volatile_ptr<GraphScene, DirectDeleter> m_scene;
+    /// scene manager
+    GraphSceneManager* m_sceneManager = nullptr;
     /// view
     GraphView* m_view = nullptr;
+    /// overlay
+    GraphViewOverlay* m_overlay = nullptr;
 };
 
 } // namespace intelli

--- a/src/intelli/gui/graphics/nodeobject.cpp
+++ b/src/intelli/gui/graphics/nodeobject.cpp
@@ -496,8 +496,7 @@ NodeGraphicsObject::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 void
 NodeGraphicsObject::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
 {
-    gt::gui::handleObjectDoubleClick(*m_node);
-
+    emit nodeDoubleClicked(this);
     event->accept();
 }
 

--- a/src/intelli/gui/graphics/nodeobject.h
+++ b/src/intelli/gui/graphics/nodeobject.h
@@ -241,6 +241,8 @@ signals:
      */
     void nodeMoved(NodeGraphicsObject* object);
 
+    void nodeDoubleClicked(NodeGraphicsObject* object);
+
     void nodeGeometryChanged(NodeGraphicsObject* object);
 
     void portContextMenuRequested(NodeGraphicsObject* object, PortId port, QPointF pos);

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -39,8 +39,6 @@ public:
     GraphScene(Graph& graph);
     ~GraphScene();
 
-    void reset();
-
     Graph& graph();
     Graph const& graph() const;
 
@@ -65,6 +63,13 @@ public:
      */
     void setSnapToGrid(bool enable = true);
 
+    /// Returns whether snap to grid is enabled
+    bool snapToGrid() const;
+
+    void setConnectionShape(ConnectionShape shape);
+
+    ConnectionShape connectionShape() const;
+
     NodeGraphicsObject* nodeObject(NodeId nodeId);
     NodeGraphicsObject const* nodeObject(NodeId nodeId) const;
 
@@ -72,8 +77,6 @@ public:
     ConnectionGraphicsObject const* connectionObject(ConnectionId conId) const;
 
     QMenu* createSceneMenu(QPointF scenePos);
-
-    void setConnectionShape(ConnectionShape shape);
 
 public slots:
 
@@ -89,6 +92,14 @@ public slots:
     bool copySelectedObjects();
 
     void pasteObjects();
+
+signals:
+
+    void graphNodeDoubleClicked(Graph* graph);
+
+    void connectionShapeChanged();
+
+    void snapToGridChanged();
 
 protected:
 
@@ -107,13 +118,13 @@ private:
     struct NodeEntry
     {
         NodeId nodeId;
-        volatile_ptr<NodeGraphicsObject, DirectDeleter> object;
+        unique_qptr<NodeGraphicsObject, DirectDeleter> object;
     };
 
     struct ConnectionEntry
     {
         ConnectionId conId;
-        volatile_ptr<ConnectionGraphicsObject, DirectDeleter> object;
+        unique_qptr<ConnectionGraphicsObject, DirectDeleter> object;
     };
 
     /// graph this scene refers to
@@ -123,15 +134,11 @@ private:
     /// Connection objects in this scene
     std::vector<ConnectionEntry> m_connections;
     /// Draft connection if active
-    volatile_ptr<ConnectionGraphicsObject> m_draftConnection;
+    unique_qptr<ConnectionGraphicsObject> m_draftConnection;
     /// Shared scene data
     std::unique_ptr<GraphSceneData> m_sceneData;
     /// Shape style of the connections in this scene
     ConnectionShape m_connectionShape = ConnectionShape::DefaultShape;
-
-    void beginReset();
-
-    void endReset();
     
     void groupNodes(QVector<NodeGraphicsObject*> const& selectedNodeObjects);
 
@@ -161,6 +168,8 @@ private slots:
     void onNodeShifted(NodeGraphicsObject* sender, QPointF diff);
 
     void onNodeMoved(NodeGraphicsObject* sender);
+
+    void onNodeDoubleClicked(NodeGraphicsObject* sender);
 
     void onConnectionAppended(Connection* con);
 

--- a/src/intelli/gui/graphscenemanager.cpp
+++ b/src/intelli/gui/graphscenemanager.cpp
@@ -1,0 +1,57 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#include <intelli/gui/graphscenemanager.h>
+
+#include <intelli/graph.h>
+#include <intelli/gui/graphview.h>
+#include <intelli/gui/graphscene.h>
+
+using namespace intelli;
+
+GraphSceneManager::GraphSceneManager(GraphView& view) :
+    QObject((QObject*)&view),
+    m_view(&view)
+{
+
+}
+
+GraphSceneManager*
+GraphSceneManager::make(GraphView& view)
+{
+    return new GraphSceneManager(view);
+}
+
+GraphScene*
+GraphSceneManager::createScene(Graph& graph)
+{
+    assert(m_view);
+
+    // if graph has scene -> abort
+    auto iter = std::find_if(m_scenes.cbegin(), m_scenes.cend(),
+                             [&graph](auto const& scene){
+        return scene && &scene->graph() == &graph;
+    });
+    if (iter != m_scenes.end())
+    {
+        // TODO: error message
+        return {};
+    }
+
+    // create scene
+    auto scenePtr = make_unique_qptr<GraphScene, DirectDeleter>(graph);
+    GraphScene* scene = scenePtr.get();
+
+    m_scenes.push_back(std::move(scenePtr));
+
+    // if view has no scene -> set scene
+    if (!m_view->nodeScene()) m_view->setScene(*scene);
+
+    return scene;
+}

--- a/src/intelli/gui/graphscenemanager.cpp
+++ b/src/intelli/gui/graphscenemanager.cpp
@@ -15,6 +15,18 @@
 
 using namespace intelli;
 
+namespace
+{
+
+inline auto findGraphOp(Graph& graph)
+{
+    return [&graph](auto const& scene){
+        return scene && &scene->graph() == &graph;
+    };
+}
+
+} // namespace
+
 GraphSceneManager::GraphSceneManager(GraphView& view) :
     QObject((QObject*)&view),
     m_view(&view)
@@ -29,18 +41,30 @@ GraphSceneManager::make(GraphView& view)
 }
 
 GraphScene*
+GraphSceneManager::currentScene()
+{
+    assert(m_view);
+    return m_view->nodeScene();
+}
+
+GraphScene const*
+GraphSceneManager::currentScene() const
+{
+    return const_cast<GraphSceneManager*>(this)->currentScene();
+}
+
+GraphScene*
 GraphSceneManager::createScene(Graph& graph)
 {
     assert(m_view);
 
     // if graph has scene -> abort
-    auto iter = std::find_if(m_scenes.cbegin(), m_scenes.cend(),
-                             [&graph](auto const& scene){
-        return scene && &scene->graph() == &graph;
-    });
+    auto iter = std::find_if(m_scenes.cbegin(), m_scenes.cend(), findGraphOp(graph));
     if (iter != m_scenes.end())
     {
-        // TODO: error message
+        gtError() << QStringLiteral("[%1]").arg(GT_CLASSNAME(GraphSceneManager))
+                  << tr("Failed to create scene for graph '%1'!")
+                         .arg(relativeNodePath(graph));
         return {};
     }
 
@@ -50,8 +74,67 @@ GraphSceneManager::createScene(Graph& graph)
 
     m_scenes.push_back(std::move(scenePtr));
 
+    connect(scene, &GraphScene::graphNodeDoubleClicked,
+            this, &GraphSceneManager::openGraph);
+
     // if view has no scene -> set scene
     if (!m_view->nodeScene()) m_view->setScene(*scene);
 
     return scene;
+}
+
+void
+GraphSceneManager::openGraph(Graph* graph)
+{
+    if (!graph)
+    {
+        gtError() << QStringLiteral("[%1]").arg(GT_CLASSNAME(GraphSceneManager))
+                  << tr("Failed to open graph! (null graph)");
+        return;
+    }
+
+    GraphScene* scene = nullptr;
+
+    auto iter = std::find_if(m_scenes.begin(), m_scenes.end(), findGraphOp(*graph));
+    if (iter == m_scenes.cend())
+    {
+        scene = createScene(*graph);
+    }
+    else
+    {
+        scene = *iter;
+    }
+
+    if (!scene)
+    {
+        gtError() << QStringLiteral("[%1]").arg(GT_CLASSNAME(GraphSceneManager))
+                  << tr("Failed to open graph! (null scene)");
+        return;
+    }
+
+    if (scene == currentScene()) return;
+
+    // switch scene
+    m_view->setScene(*scene);
+}
+
+void
+GraphSceneManager::openGraphByUuid(QString const& graphUuid)
+{
+    assert(currentScene());
+
+    auto* root = currentScene()->graph().rootGraph();
+    assert(root);
+
+    auto* graph = qobject_cast<Graph*>(root->findNodeByUuid(graphUuid));
+    if (!graph)
+    {
+        gtError() << QStringLiteral("[%1]").arg(GT_CLASSNAME(GraphSceneManager))
+                  << tr("Failed to open graph by uuid! "
+                        "(uuid '%1' not found in graph '%2'!")
+                         .arg(graphUuid, root->caption());
+        return;
+    }
+
+    openGraph(graph);
 }

--- a/src/intelli/gui/graphscenemanager.h
+++ b/src/intelli/gui/graphscenemanager.h
@@ -11,7 +11,6 @@
 #define GT_INTELLI_GRAPHSCENEMANAGER_H
 
 #include <intelli/memory.h>
-#include <intelli/globals.h>
 
 #include <QObject>
 #include <QPointer>
@@ -44,7 +43,37 @@ public:
      */
     static GraphSceneManager* make(GraphView& view);
 
+    /**
+     * @brief Returns the current scene of the view.
+     * @return Current scene (may be null if no scene was registered)
+     */
+    GraphScene* currentScene();
+    GraphScene const* currentScene() const;
+
+    /**
+     * @brief Creates a new scene for the given graph. Fails if a scene is
+     * already registered for the given graph. If the scene is the only one
+     * registered it is also set as the current scene.
+     * @param graph Graph to create a scene for.
+     * @return
+     */
     GraphScene* createScene(Graph& graph);
+
+public slots:
+
+    /**
+     * @brief Opens the graph in a new scene. The scene is created if it does
+     * not exist already.
+     * @param graph Graph to open
+     */
+    void openGraph(Graph* graph);
+
+    /**
+     * @brief Opens the graph referenced by the given uuid in a new scene.
+     * The scene is created if it does not exist already.
+     * @param graph Graph to open
+     */
+    void openGraphByUuid(QString const& graphUuid);
 
 private:
 

--- a/src/intelli/gui/graphscenemanager.h
+++ b/src/intelli/gui/graphscenemanager.h
@@ -1,0 +1,58 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#ifndef GT_INTELLI_GRAPHSCENEMANAGER_H
+#define GT_INTELLI_GRAPHSCENEMANAGER_H
+
+#include <intelli/memory.h>
+#include <intelli/globals.h>
+
+#include <QObject>
+#include <QPointer>
+
+namespace intelli
+{
+
+class Graph;
+class GraphScene;
+class GraphView;
+
+/**
+ * @brief The GraphSceneManager class. Handles the creation and lifetime of
+ * scenes and can be used to easily switch between scenes.
+ */
+class GraphSceneManager : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    GraphSceneManager(GraphView& view);
+
+    /**
+     * @brief Creates a scene manager object for the view. Ownership is
+     * taken care of. The scene manager can be used to easily switch between
+     * scenes and to cleanup scenes once the view is destroyed.
+     * @param view View to create scene manager for.
+     * @return Pointer to scene manager.
+     */
+    static GraphSceneManager* make(GraphView& view);
+
+    GraphScene* createScene(Graph& graph);
+
+private:
+
+    QPointer<GraphView> m_view;
+
+    std::vector<unique_qptr<GraphScene, DirectDeleter>> m_scenes;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_GRAPHSCENEMANAGER_H

--- a/src/intelli/gui/graphsceneselector.cpp
+++ b/src/intelli/gui/graphsceneselector.cpp
@@ -13,6 +13,7 @@
 
 #include <QLabel>
 #include <QVBoxLayout>
+#include <QFontDatabase>
 
 using namespace intelli;
 
@@ -25,12 +26,12 @@ GraphSceneSelector::GraphSceneSelector(QWidget* parent) :
     m_scenePath->setTextFormat(Qt::RichText);
     m_scenePath->setTextInteractionFlags(Qt::LinksAccessibleByMouse);
 
-    connect(this, &GraphSceneSelector::graphSelected,
-            this, [](QString const& link){
-        gtDebug() << "CLICKED:" << link;
-    });
+    QFont font = m_scenePath->font();
+    font.setPointSize(font.pointSize() + 2);
+    m_scenePath->setFont(font);
+
     connect(m_scenePath, &QLabel::linkActivated,
-            this, &GraphSceneSelector::graphSelected);
+            this, &GraphSceneSelector::graphClicked);
 
     auto* lay = new QVBoxLayout(this);
     lay->addWidget(m_scenePath);
@@ -40,7 +41,7 @@ GraphSceneSelector::GraphSceneSelector(QWidget* parent) :
 void
 GraphSceneSelector::setCurrentGraph(Graph& graph)
 {
-    m_currentGraph = graph.rootGraph();
+    m_currentGraph = &graph;
     assert(m_currentGraph);
 
     refresh();

--- a/src/intelli/gui/graphsceneselector.cpp
+++ b/src/intelli/gui/graphsceneselector.cpp
@@ -1,0 +1,83 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#include <intelli/gui/graphsceneselector.h>
+
+#include <intelli/graph.h>
+
+#include <QLabel>
+#include <QVBoxLayout>
+
+using namespace intelli;
+
+GraphSceneSelector::GraphSceneSelector(QWidget* parent) :
+    QWidget(parent)
+{
+    assert(!layout());
+
+    m_scenePath = new QLabel;
+    m_scenePath->setTextFormat(Qt::RichText);
+    m_scenePath->setTextInteractionFlags(Qt::LinksAccessibleByMouse);
+
+    connect(this, &GraphSceneSelector::graphSelected,
+            this, [](QString const& link){
+        gtDebug() << "CLICKED:" << link;
+    });
+    connect(m_scenePath, &QLabel::linkActivated,
+            this, &GraphSceneSelector::graphSelected);
+
+    auto* lay = new QVBoxLayout(this);
+    lay->addWidget(m_scenePath);
+    lay->setContentsMargins(0, 0, 0, 0);
+}
+
+void
+GraphSceneSelector::setCurrentGraph(Graph& graph)
+{
+    m_currentGraph = graph.rootGraph();
+    assert(m_currentGraph);
+
+    refresh();
+}
+
+void
+GraphSceneSelector::clear()
+{
+    m_scenePath->clear();
+}
+
+void
+GraphSceneSelector::refresh()
+{
+    clear();
+
+    if (!m_currentGraph) return;
+
+    QString text;
+
+    Graph* graph = m_currentGraph;
+    while (graph)
+    {
+        graph->disconnect(this);
+
+        connect(graph, &QObject::destroyed,
+                this, &GraphSceneSelector::refresh);
+        connect(graph, &QObject::objectNameChanged,
+                this, &GraphSceneSelector::refresh);
+
+        if (!text.isEmpty()) text.push_front(QStringLiteral(" / "));
+
+        text.push_front(QStringLiteral("<a href=\"%1\">%2</a>")
+                            .arg(graph->uuid(), graph->caption()));
+
+        graph = graph->parentGraph();
+    }
+
+    m_scenePath->setText(std::move(text));
+}

--- a/src/intelli/gui/graphsceneselector.h
+++ b/src/intelli/gui/graphsceneselector.h
@@ -1,0 +1,62 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#ifndef GT_INTELLI_GRAPHSCENESELECTOR_H
+#define GT_INTELLI_GRAPHSCENESELECTOR_H
+
+#include <intelli/globals.h>
+
+#include <QWidget>
+#include <QPointer>
+
+class QLabel;
+
+namespace intelli
+{
+
+class Graph;
+
+/**
+ * @brief The GraphSceneSelector class. Widget that displays the hierarchy
+ * of the current scene as a path. Can be used to traverse between graph levels.
+ */
+class GraphSceneSelector : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    GraphSceneSelector(QWidget* parent = nullptr);
+
+    /**
+     * @brief Refreshes the scene path of the widget. Must be called once the
+     * scene changes
+     * @param graph Current graph
+     */
+    void setCurrentGraph(Graph& graph);
+
+public slots:
+
+    void clear();
+
+    void refresh();
+
+signals:
+
+    void graphSelected(NodeUuid const& graphUuid);
+
+private:
+
+    QPointer<Graph> m_currentGraph;
+    QLabel* m_scenePath;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_GRAPHSCENESELECTOR_H

--- a/src/intelli/gui/graphsceneselector.h
+++ b/src/intelli/gui/graphsceneselector.h
@@ -10,8 +10,6 @@
 #ifndef GT_INTELLI_GRAPHSCENESELECTOR_H
 #define GT_INTELLI_GRAPHSCENESELECTOR_H
 
-#include <intelli/globals.h>
-
 #include <QWidget>
 #include <QPointer>
 
@@ -49,7 +47,7 @@ public slots:
 
 signals:
 
-    void graphSelected(NodeUuid const& graphUuid);
+    void graphClicked(QString const& graphUuid);
 
 private:
 

--- a/src/intelli/gui/graphstatemanager.cpp
+++ b/src/intelli/gui/graphstatemanager.cpp
@@ -1,0 +1,118 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#include <intelli/gui/graphstatemanager.h>
+
+#include <intelli/graphexecmodel.h>
+#include <intelli/gui/graphview.h>
+#include <intelli/gui/graphscene.h>
+#include <intelli/graph.h>
+#include <intelli/private/utils.h>
+
+using namespace intelli;
+
+GraphStateManager::GraphStateManager(Graph& graph, GraphView& view) :
+    QObject((QObject*)&view),
+    m_view(&view),
+    m_guardian(make_unique_qptr<GtObject>())
+{
+    m_guardian->setParent((QObject*)&view);
+
+    // grid visible state
+    auto* v = &view;
+
+    auto getGridVisible = std::bind(&GraphView::isGridVisible, v);
+
+    utils::setupState<GraphView>(*m_guardian, graph, tr("Show Grid"), getGridVisible)
+        .onStateChange(v, [v](QVariant const& show){ v->showGrid(show.toBool()); })
+        .onValueChange(v, &GraphView::gridVisibilityChanged)
+        .finalize();
+
+    connect(m_view, &GraphView::sceneChanged,
+            this, &GraphStateManager::onSceneChanged);
+
+    if (GraphScene* scene = m_view->nodeScene())
+    {
+        onSceneChanged(scene);
+    }
+}
+
+GraphStateManager*
+GraphStateManager::make(Graph& graph, GraphView &view)
+{
+    return new GraphStateManager(graph, view);
+}
+
+GtObject*
+GraphStateManager::guardianObject()
+{
+    return m_guardian;
+}
+
+void
+GraphStateManager::onSceneChanged(GraphScene* scene)
+{
+    assert(m_view);
+    assert(m_guardian);
+    if (!scene) return;
+
+    auto& graph = scene->graph();
+    auto& guardian = *m_guardian;
+
+    // snap to grid state
+    auto getSnapToGrid = std::bind(&GraphScene::snapToGrid, scene);
+
+    utils::setupState<GraphScene>(guardian, graph, tr("Snap to Grid"), getSnapToGrid)
+        .onStateChange(scene, [scene](QVariant const& enable) { scene->setSnapToGrid(enable.toBool()); })
+        .onValueChange(scene, &GraphScene::snapToGridChanged)
+        .finalize();
+
+    // connection style state
+    auto getConnectionShape = [scene](){ return (qulonglong)(scene->connectionShape()); };
+
+    utils::setupState<GraphScene>(guardian, graph, tr("Connection Shape"), getConnectionShape)
+        .onStateChange(scene, [scene](QVariant const& value) {
+            // could not get Q_DECLARE_METATYPE to work
+            ConnectionShape shape = ConnectionShape::DefaultShape;
+            switch (value.value<qulonglong>())
+            {
+            case (qulonglong)ConnectionShape::Cubic:
+                shape = ConnectionShape::Cubic;
+                break;
+            case (qulonglong)ConnectionShape::Rectangle:
+                shape = ConnectionShape::Rectangle;
+                break;
+            case (qulonglong)ConnectionShape::Straight:
+                shape = ConnectionShape::Straight;
+                break;
+            }
+            scene->setConnectionShape(shape);
+        })
+        .onValueChange(scene, &GraphScene::connectionShapeChanged)
+        .finalize();
+
+    // auto evaluation state
+    auto* model = GraphExecutionModel::accessExecModel(graph);
+    if (!model) return;
+
+    auto getAutoEvaluationEnabled =
+        std::bind(qOverload<>(&GraphExecutionModel::isAutoEvaluatingGraph), model);
+
+    utils::setupState<GraphExecutionModel>(guardian, graph, tr("Auto Evaluation"),
+                                           getAutoEvaluationEnabled)
+        .onStateChange(model, [model](QVariant const& enable) {
+            bool autoEvaluate = enable.toBool();
+            if (autoEvaluate == model->isAutoEvaluatingGraph()) return;
+
+            autoEvaluate ? (void)model->autoEvaluateGraph() :
+                           (void)model->stopAutoEvaluatingGraph();
+        })
+        .onValueChange(model, &GraphExecutionModel::autoEvaluationChanged)
+        .finalize();
+}

--- a/src/intelli/gui/graphstatemanager.h
+++ b/src/intelli/gui/graphstatemanager.h
@@ -1,0 +1,63 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#ifndef GT_INTELLI_GRAPHSTATEMANAGER_H
+#define GT_INTELLI_GRAPHSTATEMANAGER_H
+
+#include <intelli/memory.h>
+
+#include <QObject>
+#include <QPointer>
+
+class GtObject;
+
+namespace intelli
+{
+
+class Graph;
+class GraphView;
+class GraphScene;
+
+/**
+ * @brief The GraphStateManager class. Handles the state creation for a graph
+ * instance and its associated graph view. Can be used to save view, scene and
+ * exec states persistently.
+ */
+class GraphStateManager : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    GraphStateManager(Graph& graph, GraphView& view);
+
+    /**
+     * @brief Creates a state manager instance for view object. Ownership is
+     * taken care of.
+     * @param view View to create state manager for
+     * @return Pointer to state manager.
+     */
+    static GraphStateManager* make(Graph& graph, GraphView& view);
+
+    GtObject* guardianObject();
+
+private slots:
+
+    void onSceneChanged(GraphScene* scene);
+
+private:
+
+    QPointer<GraphView> m_view;
+
+    unique_qptr<GtObject> m_guardian;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_GRAPHSTATEMANAGER_H

--- a/src/intelli/gui/graphview.h
+++ b/src/intelli/gui/graphview.h
@@ -14,12 +14,14 @@
 
 class QMenu;
 class QPushButton;
-class GtGrid;
+class GtObject;
 
 namespace intelli
 {
 
+class Graph;
 class GraphScene;
+class GraphSceneSelector;
 
 class GraphView : public GtGraphicsView
 {
@@ -34,7 +36,7 @@ public:
     };
     
     GraphView(QWidget* parent = nullptr);
-    
+
     void setScene(GraphScene& scene);
 
     /// @brief max=0/min=0 indicates infinite zoom in/out
@@ -42,8 +44,20 @@ public:
 
     void setScaleRange(ScaleRange range);
 
+    /// Returns the current major grid size
+    int minorGridSize() const;
+    /// Returns the current major grid size
+    int majorGridSize() const;
+
+    /// Returns whether the grid is visible
+    bool isGridVisible() const;
+    /// Sets whether the grid should be visible or not
+    void showGrid(bool show = true);
+
+    /// Returns the current scale
     double scale() const;
-    
+
+    /// Returns the current graph scene
     GraphScene* nodeScene();
 
 public slots:
@@ -56,19 +70,15 @@ public slots:
 
     void setScale(double scale);
 
-private slots:
-
-    void printPDF();
+    void printToPDF();
 
 signals:
 
-    void scaleChanged(double scale);
+    void scaleChanged(double scale, QPrivateSignal);
 
-    void gridChanged(QPrivateSignal);
+    void sceneChanged(GraphScene* scene);
 
-    void connectionShapeChanged(QPrivateSignal);
-
-    void autoEvaluationChanged(QPrivateSignal);
+    void gridVisibilityChanged();
 
 protected:
 
@@ -85,17 +95,18 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
 
 private:
+
+    /// hide grid API as is provides a poor interface
+    using GtGraphicsView::grid;
+
     struct Impl;
 
+    /// scale range
     ScaleRange m_scaleRange;
+    /// last pan position
     QPointF m_panPosition;
-
-    QMenu* m_sceneMenu = nullptr;
-    QMenu* m_editMenu = nullptr;
-
-    QPushButton* m_startAutoEvalBtn = nullptr;
-    QPushButton* m_stopAutoEvalBtn = nullptr;
-    QPushButton* m_snapToGridBtn = nullptr;
+    /// accessing grid visibility through grid API is not possible
+    bool m_gridVisible = true;
 };
 
 } // namespace intelli

--- a/src/intelli/gui/graphviewoverlay.cpp
+++ b/src/intelli/gui/graphviewoverlay.cpp
@@ -166,6 +166,9 @@ GraphViewOverlay::GraphViewOverlay(GraphView& view) :
     /* SCENE-LINK */
     m_sceneSelector = new GraphSceneSelector;
 
+    connect(m_sceneSelector, &GraphSceneSelector::graphClicked,
+            this, &GraphViewOverlay::sceneChangeRequested);
+
     /* OVERLAY */
     setContentsMargins(5, 5, 5, 0);
     setAlignment(Qt::AlignLeft | Qt::AlignTop);
@@ -174,6 +177,7 @@ GraphViewOverlay::GraphViewOverlay(GraphView& view) :
     insertWidget(idx++, m_startAutoEvalBtn);
     insertWidget(idx++, m_stopAutoEvalBtn);
     insertWidget(idx++, m_snapToGridBtn);
+    insertSpacing(idx , m_snapToGridBtn->width());
     insertWidget(idx++, m_sceneSelector);
     addStretch();
 

--- a/src/intelli/gui/graphviewoverlay.cpp
+++ b/src/intelli/gui/graphviewoverlay.cpp
@@ -1,0 +1,246 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#include <intelli/gui/graphviewoverlay.h>
+
+#include <intelli/graph.h>
+#include <intelli/graphexecmodel.h>
+#include <intelli/gui/graphview.h>
+#include <intelli/gui/graphscene.h>
+#include <intelli/gui/graphsceneselector.h>
+
+#include <gt_objectuiaction.h>
+#include <gt_icons.h>
+#include <gt_colors.h>
+#include <gt_guiutilities.h>
+
+#include <QMenu>
+#include <QMenuBar>
+#include <QPushButton>
+#include <QSpacerItem>
+
+using namespace intelli;
+
+GraphViewOverlay::GraphViewOverlay(GraphView& view) :
+    QHBoxLayout(&view),
+    m_view(&view)
+{
+    m_menuBar = new QMenuBar;
+
+    // helper function to create a separator
+    auto const makeSeparator = [](){
+        return GtObjectUIAction();
+    };
+
+    // helper function to setup scene buttons
+    auto setupBtn = [](){
+        auto* btn = new QPushButton();
+        btn->setVisible(false);
+        btn->setEnabled(false);
+        auto height = btn->sizeHint().height();
+        btn->setFixedSize(QSize(height, height));
+        return btn;
+    };
+
+    m_snapToGridBtn = setupBtn();
+    m_startAutoEvalBtn = setupBtn();
+    m_stopAutoEvalBtn = setupBtn();
+
+    /* SLOTS */
+    auto changeGridVisibility = [this](auto){
+        bool wasVisible = m_view->isGridVisible();
+        m_view->showGrid(!wasVisible);
+        m_snapToGridBtn->setVisible(!wasVisible);
+
+        auto* scene = m_view->nodeScene();
+        if (!scene) return;
+
+        scene->setSnapToGrid(!wasVisible && m_snapToGridBtn->isChecked());
+    };
+
+    auto changeConnectionShape = [this](auto){
+        if (auto* scene = m_view->nodeScene())
+        {
+            auto shape = nextConnectionShape(scene->connectionShape());
+            scene->setConnectionShape(shape);
+        }
+    };
+
+    auto changeSnapToGrid = [this](){
+        if (auto* scene = m_view->nodeScene())
+        {
+            scene->setSnapToGrid(m_snapToGridBtn->isChecked());
+        }
+    };
+
+    auto updateAutoEvaluation = [this](bool autoEvaluate) {
+        GraphScene* scene = m_view->nodeScene();
+        if (!scene) return;
+
+        auto* model = GraphExecutionModel::accessExecModel(scene->graph());
+        if (!model) return;
+
+        autoEvaluate ? (void)model->autoEvaluateGraph(scene->graph()) :
+                       (void)model->stopAutoEvaluatingGraph(scene->graph());
+    };
+
+    /* VIEW MENU */
+    m_viewMenu = m_menuBar->addMenu(tr("View"));
+    m_viewMenu->setEnabled(true);
+
+    auto resetScaleAction =
+        gt::gui::makeAction(tr("Reset scale"),
+                            std::bind(&GraphView::setScale, m_view, 1.0))
+            .setIcon(gt::gui::icon::revert());
+
+    auto centerSceneAction =
+        gt::gui::makeAction(tr("Center view"),
+                            std::bind(&GraphView::centerScene, m_view))
+            .setIcon(gt::gui::icon::select());
+
+    auto changeGridAction =
+        gt::gui::makeAction(tr("Toggle Grid"), changeGridVisibility)
+            .setIcon(gt::gui::icon::grid());
+
+    auto changeConShapeAction =
+        gt::gui::makeAction(tr("Toggle Connection Shape"), changeConnectionShape)
+            .setIcon(gt::gui::icon::vectorBezier2());
+
+    auto printAction =
+        gt::gui::makeAction(tr("Print to PDF"),
+                            std::bind(&GraphView::printToPDF, m_view))
+            .setIcon(gt::gui::icon::pdf());
+
+    gt::gui::addToMenu(resetScaleAction, *m_viewMenu, nullptr);
+    gt::gui::addToMenu(centerSceneAction, *m_viewMenu, nullptr);
+    gt::gui::addToMenu(changeConShapeAction, *m_viewMenu, nullptr);
+    gt::gui::addToMenu(changeGridAction, *m_viewMenu, nullptr);
+    gt::gui::addToMenu(makeSeparator(), *m_viewMenu, nullptr);
+    gt::gui::addToMenu(printAction, *m_viewMenu, nullptr);
+
+    /* EDIT MENU */
+    m_sceneMenu = m_menuBar->addMenu(tr("Scene"));
+    m_sceneMenu->setEnabled(false);
+
+    auto const& viewActions = m_view->actions();
+    m_sceneMenu->addActions(viewActions);
+
+    /* AUTO EVAL */
+    m_startAutoEvalBtn->setToolTip(tr("Enable automatic graph evaluation"));
+    m_startAutoEvalBtn->setIcon(gt::gui::icon::play());
+    m_startAutoEvalBtn->setVisible(true);
+
+    m_stopAutoEvalBtn->setToolTip(tr("Stop automatic graph evaluation"));
+    m_stopAutoEvalBtn->setIcon(gt::gui::icon::stop());
+    m_stopAutoEvalBtn->setVisible(false);
+
+    connect(m_startAutoEvalBtn, &QPushButton::clicked,
+        this, std::bind(updateAutoEvaluation, true));
+    connect(m_stopAutoEvalBtn, &QPushButton::clicked,
+            this, std::bind(updateAutoEvaluation, false));
+
+    /* SNAP TO GRID */
+    m_snapToGridBtn->setCheckable(true);
+    m_snapToGridBtn->setToolTip(tr("Toggle snap to grid"));
+    m_snapToGridBtn->setVisible(m_view->isGridVisible());
+    m_snapToGridBtn->setEnabled(false);
+
+    connect(m_snapToGridBtn, &QPushButton::clicked, this, changeSnapToGrid);
+
+    using namespace gt::gui;
+    // checked button do not use On/Off Icons, thus we have to update the
+    // icon ourselfes (adapted from `GtOutputDock`)
+    auto const onCheckedColor = [b = QPointer<QPushButton>(m_snapToGridBtn)](){
+        assert (b);
+        return b->isChecked() ? color::text() :
+                                color::lighten(color::disabled(), 15);
+    };
+    m_snapToGridBtn->setIcon(colorize(icon::gridSnap(), SvgColorData{ onCheckedColor }));
+
+    /* SCENE-LINK */
+    m_sceneSelector = new GraphSceneSelector;
+
+    /* OVERLAY */
+    setContentsMargins(5, 5, 5, 0);
+    setAlignment(Qt::AlignLeft | Qt::AlignTop);
+    int idx = 0;
+    insertWidget(idx++, m_menuBar);
+    insertWidget(idx++, m_startAutoEvalBtn);
+    insertWidget(idx++, m_stopAutoEvalBtn);
+    insertWidget(idx++, m_snapToGridBtn);
+    insertWidget(idx++, m_sceneSelector);
+    addStretch();
+
+    auto size = m_menuBar->sizeHint();
+    size.setWidth(size.width() + 10);
+    m_menuBar->setFixedSize(size);
+
+    connect(m_view, &GraphView::sceneChanged,
+            this, &GraphViewOverlay::onSceneChanged);
+
+    if (GraphScene* scene = m_view->nodeScene())
+    {
+        onSceneChanged(scene);
+    }
+}
+
+GraphViewOverlay*
+GraphViewOverlay::make(GraphView& view)
+{
+    return new GraphViewOverlay(view);
+}
+
+void
+GraphViewOverlay::onSceneChanged(GraphScene* scene)
+{
+    assert(m_view);
+    if (!scene) return;
+
+    auto& graph = scene->graph();
+
+    m_sceneSelector->setCurrentGraph(graph);
+
+    m_startAutoEvalBtn->setEnabled(true);
+    m_stopAutoEvalBtn->setEnabled(true);
+    m_snapToGridBtn->setEnabled(true);
+    m_snapToGridBtn->setVisible(m_view->isGridVisible());
+
+    m_sceneMenu->setEnabled(true);
+
+    auto onSnapToGridChanged = [this](){
+        if (!m_snapToGridBtn->isVisible()) return;
+        if (auto* scene = m_view->nodeScene())
+        {
+            m_snapToGridBtn->setChecked(scene->snapToGrid());
+        }
+    };
+
+    auto* model = GraphExecutionModel::accessExecModel(graph);
+    if (!model) return;
+
+    auto onAutoEvaluationChanged = [this, model](){
+        GraphScene* scene = m_view->nodeScene();
+        if (!scene) return;
+
+        bool autoEvaluate = model->isAutoEvaluatingGraph(scene->graph());
+
+        m_startAutoEvalBtn->setVisible(!autoEvaluate);
+        m_stopAutoEvalBtn->setVisible(autoEvaluate);
+    };
+
+    connect(model, &GraphExecutionModel::autoEvaluationChanged,
+            this, onAutoEvaluationChanged);
+
+    connect(scene, &GraphScene::snapToGridChanged,
+            m_view, onSnapToGridChanged);
+
+    // update once
+    onSnapToGridChanged();
+    onAutoEvaluationChanged();
+}

--- a/src/intelli/gui/graphviewoverlay.h
+++ b/src/intelli/gui/graphviewoverlay.h
@@ -1,0 +1,70 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#ifndef GT_INTELLI_GRAPHVIEWOVERLAY_H
+#define GT_INTELLI_GRAPHVIEWOVERLAY_H
+
+#include <QHBoxLayout>
+
+#include <QPointer>
+
+class QMenu;
+class QMenuBar;
+class QPushButton;
+
+namespace intelli
+{
+
+class GraphScene;
+class GraphSceneSelector;
+class GraphView;
+
+/**
+ * @brief The GraphViewOverlay class. Instanties an overlay widget ontop of a
+ * graph view instance. The overlay can be used to control view, scene and exec
+ * properties.
+ */
+class GraphViewOverlay : public QHBoxLayout
+{
+    Q_OBJECT
+
+public:
+
+    GraphViewOverlay(GraphView& view);
+
+    /**
+     * @brief Creates an overlay widget ontop the view object. Ownership is
+     * taken care of.
+     * @param view View to create overlay widget for
+     * @return Pointer to overlay widget.
+     */
+    static GraphViewOverlay* make(GraphView& view);
+
+private:
+
+    QPointer<GraphView> m_view;
+
+    QMenuBar* m_menuBar = nullptr;
+    QMenu* m_viewMenu = nullptr;
+    QMenu* m_sceneMenu = nullptr;
+
+    QPushButton* m_startAutoEvalBtn = nullptr;
+    QPushButton* m_stopAutoEvalBtn = nullptr;
+    QPushButton* m_snapToGridBtn = nullptr;
+
+    GraphSceneSelector* m_sceneSelector = nullptr;
+
+private slots:
+
+    void onSceneChanged(GraphScene* scene);
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_GRAPHVIEWOVERLAY_H

--- a/src/intelli/gui/graphviewoverlay.h
+++ b/src/intelli/gui/graphviewoverlay.h
@@ -46,6 +46,10 @@ public:
      */
     static GraphViewOverlay* make(GraphView& view);
 
+signals:
+
+    void sceneChangeRequested(QString const& graphUuid);
+
 private:
 
     QPointer<GraphView> m_view;

--- a/src/intelli/gui/style.h
+++ b/src/intelli/gui/style.h
@@ -27,6 +27,21 @@ enum class ConnectionShape : size_t
     DefaultShape = Cubic
 };
 
+inline constexpr ConnectionShape
+nextConnectionShape(ConnectionShape shape)
+{
+    switch (shape)
+    {
+    case ConnectionShape::Cubic:
+        return ConnectionShape::Rectangle;
+    case ConnectionShape::Rectangle:
+        return ConnectionShape::Straight;
+    case ConnectionShape::Straight:
+        return ConnectionShape::Cubic;
+    }
+    return ConnectionShape::DefaultShape;
+}
+
 namespace style
 {
 

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -48,7 +48,6 @@
 #include <QDomNodeList>
 
 using namespace intelli;
-
 // non namespace variants
 static const int meta_port_index = [](){
     return qRegisterMetaType<PortIndex>("PortIndex");

--- a/src/intelli/node.h
+++ b/src/intelli/node.h
@@ -13,6 +13,7 @@
 #include <intelli/globals.h>
 #include <intelli/exports.h>
 
+#include <gt_typetraits.h>
 #include <gt_object.h>
 
 #include <QWidget>
@@ -748,6 +749,20 @@ struct get_node_id<NodeUuid>
 {
     NodeUuid operator()(Node const* node) { assert(node); return node->uuid(); }
 };
+
+/**
+ * @brief Returns the relative path to the root node.
+ * @param node Target node
+ * @return Relative node path
+ */
+inline QString
+relativeNodePath(Node const& node)
+{
+    auto const* root = node.template findRoot<Node const*>();
+    if (!root) return node.caption();
+
+    return root->caption() + (node.objectPath().remove(root->objectPath())).replace(';', '/');
+}
 
 } // namespace intelli
 

--- a/src/intelli/private/graphexecmodel_impl.h
+++ b/src/intelli/private/graphexecmodel_impl.h
@@ -963,6 +963,8 @@ struct GraphExecutionModel::Impl
 
         evaluateNextInQueue(model);
 
+        emit model.autoEvaluationChanged(&graph);
+
         return true;
     }
 

--- a/src/intelli/private/graphexecmodel_impl.h
+++ b/src/intelli/private/graphexecmodel_impl.h
@@ -854,6 +854,17 @@ struct GraphExecutionModel::Impl
         list = gt::topo_sort(adjacencyMatrix);
     }
 
+    /// Removes all nodes from the given list that were already evaluated
+    static inline void
+    removeEvaluatedNodes(GraphExecutionModel& model, std::vector<NodeUuid>& nodes)
+    {
+        nodes.erase(std::remove_if(nodes.begin(), nodes.end(), [&model](const auto& uuid) {
+            auto item = findData(model, uuid);
+            assert(item);
+            return item.isEvaluated();
+        }), nodes.end());
+    }
+
     /**
      * @brief Reschedules all target nodes and appends them to the list of
      * pending nodes
@@ -876,6 +887,8 @@ struct GraphExecutionModel::Impl
         }
 
         sortDependencies(model, model.m_pendingNodes);
+
+        removeEvaluatedNodes(model, model.m_pendingNodes);
 
         INTELLI_LOG(model) << "pending nodes:"
                            << model.m_pendingNodes;
@@ -1088,6 +1101,14 @@ struct GraphExecutionModel::Impl
                 << QObject::tr("scheduling target node '%1'...")
                        .arg(nodeUuid);
 
+            if (!model.m_data.contains(nodeUuid))
+            {
+                INTELLI_LOG_WARN(model)
+                    << QObject::tr("node not found!");
+                // should make future fail
+                return ExecFuture{model};
+            }
+
             if (!utils::contains(model.m_targetNodes, nodeUuid))
             {
                 model.m_targetNodes.push_back(nodeUuid);
@@ -1116,6 +1137,13 @@ struct GraphExecutionModel::Impl
         INTELLI_LOG_SCOPE(model)
             << QObject::tr("scheduling target node '%1'...")
                    .arg(nodeUuid);
+
+        if (!model.m_data.contains(nodeUuid))
+        {
+            INTELLI_LOG_WARN(model)
+                << QObject::tr("node not found!");
+            return ExecFuture{model};
+        }
 
         // append to target nodes
         if (!utils::contains(model.m_targetNodes, nodeUuid))
@@ -1224,6 +1252,8 @@ struct GraphExecutionModel::Impl
             model.m_autoEvaluatingNodes.end()
         };
         sortDependencies(model, dummy);
+
+        removeEvaluatedNodes(model, dummy);
 
         INTELLI_LOG_SCOPE(model)
             << tr("scheduling auto evaluating nodes:")

--- a/tests/unittests/test_graphexecmodel.cpp
+++ b/tests/unittests/test_graphexecmodel.cpp
@@ -546,7 +546,7 @@ TEST(GraphExecutionModel, evaluate_graph_with_node_appended)
 
     bool functionCalled = false;
 
-    gtTrace() << "Scheudling callback function...";
+    gtTrace() << "Scheduling callback function...";
 
     model.evaluateNode(A_uuid).then([&graph, &functionCalled](bool success){
         gtTrace() << "Callback function called!";

--- a/tests/unittests/test_helper.h
+++ b/tests/unittests/test_helper.h
@@ -19,6 +19,8 @@
 
 #include "intelli/private/utils.h"
 
+#include <cmath>
+
 namespace intelli
 {
 


### PR DESCRIPTION
Closes #97

Double clicking a subgraph will now open it in the same viewer but in a nested level. The level can be traversed "upwards" using a graph/scene selection widget in the overlay. 

In addition...
 - the Overlay-Widget was moved to a separate class. 
 - The scenes and changing of the current scene is handles by a scene manager class
 - The states were moved to their corresponding classes instead of everything being handled by the view class
 - The exec model and auto evaluation state was move out of the view and scene class into the graph editor thus reducing coupling even more.

### Example

Initially we start at the root level:

![grafik](https://github.com/user-attachments/assets/24a9165b-ddc7-44e2-af2f-bbdf196f0df9)

Double clicking the subgraph and thus traversing the hierarchy "downwards" we will end up in the most nested graph. The graph/scene selector is updated accordingly and can be used to move to a higher level:

![grafik](https://github.com/user-attachments/assets/89072e8f-2065-4e58-bfb4-43810d9645a9)
 