### PR TITLE
Resolve: "The number input nodes falsely trigger an evaluation if no value change has occured"

### DIFF
--- a/src/intelli/gui/property_item/doubleinputwidget.cpp
+++ b/src/intelli/gui/property_item/doubleinputwidget.cpp
@@ -251,24 +251,24 @@ DoubleInputWidget::toSliderVLayout()
 void
 DoubleInputWidget::disconnectDial()
 {
-    disconnect(m_dial, SIGNAL(valueChanged(int)),
-               this, SLOT(onDialChanged(int)));
     disconnect(m_dial, SIGNAL(sliderReleased()),
-               this, SIGNAL(sliderReleased()));
+               this, SLOT(onDialChanged()));
 }
 
 void
 DoubleInputWidget::connectDial()
 {
-    connect(m_dial, SIGNAL(valueChanged(int)),
-            this, SLOT(onDialChanged(int)));
     connect(m_dial, SIGNAL(sliderReleased()),
-            this, SIGNAL(sliderReleased()));
+            this, SLOT(onDialChanged()));
 }
 
 void
-DoubleInputWidget::onDialChanged(int newDialVal)
+DoubleInputWidget::onDialChanged()
 {
+    if (m_dial == nullptr) return;
+
+    int newDialVal = m_dial->value();
+
     double newVal =
             m_min + double(newDialVal) / double(m_maxTicks) * (m_max - m_min);
 

--- a/src/intelli/gui/property_item/doubleinputwidget.h
+++ b/src/intelli/gui/property_item/doubleinputwidget.h
@@ -33,8 +33,6 @@ public:
 signals:
     void valueChanged(double newVal);
 
-    void sliderReleased();
-
     void onMinLabelChanged(double newVal);
 
     void onMaxLabelChanged(double newVal);
@@ -78,7 +76,7 @@ private:
     void connectDial();
 
 private slots:
-    void onDialChanged(int newDialVal);
+    void onDialChanged();
 
     void minLabelChangedReaction(double newVal);
 

--- a/src/intelli/gui/property_item/integerinputwidget.cpp
+++ b/src/intelli/gui/property_item/integerinputwidget.cpp
@@ -242,24 +242,23 @@ IntegerInputWidget::toSliderVLayout()
 void
 IntegerInputWidget::disconnectDial()
 {
-    disconnect(m_dial, SIGNAL(valueChanged(int)),
-               this, SLOT(onDialChanged(int)));
     disconnect(m_dial, SIGNAL(sliderReleased()),
-               this, SIGNAL(sliderReleased()));
+               this, SLOT(onDialChanged()));
 }
 
 void
 IntegerInputWidget::connectDial()
 {
-    connect(m_dial, SIGNAL(valueChanged(int)),
-            this, SLOT(onDialChanged(int)));
     connect(m_dial, SIGNAL(sliderReleased()),
-            this, SIGNAL(sliderReleased()));
+            this, SLOT(onDialChanged()));
 }
 
 void
-IntegerInputWidget::onDialChanged(int newDialVal)
+IntegerInputWidget::onDialChanged()
 {
+    if (m_dial == nullptr) return;
+
+    int newDialVal = m_dial->value();
     m_text->setText(QString::number(newDialVal));
 
     emit valueChanged(newDialVal);

--- a/src/intelli/gui/property_item/integerinputwidget.h
+++ b/src/intelli/gui/property_item/integerinputwidget.h
@@ -33,8 +33,6 @@ public:
 signals:
     void valueChanged(int newVal);
 
-    void sliderReleased();
-
     void onMinLabelChanged(int newVal);
 
     void onMaxLabelChanged(int newVal);
@@ -78,7 +76,7 @@ private:
     void connectDial();
 
 private slots:
-    void onDialChanged(int newDialVal);
+    void onDialChanged();
 
     void minLabelChangedReaction(int newVal);
 

--- a/src/intelli/node/propertyinput/doubleinputnode.cpp
+++ b/src/intelli/node/propertyinput/doubleinputnode.cpp
@@ -101,8 +101,11 @@ DoubleInputNode::DoubleInputNode() :
 
         auto onValueLabelChanged = [=](double newVal)
         {
-            if (value() != newVal) setValue(newVal);
-            triggerNodeEvaluation();
+            if (value() != newVal)
+            {
+                setValue(newVal);
+                triggerNodeEvaluation();
+            }
         };
 
         auto onDisplyModeChanged = [=]()
@@ -112,8 +115,6 @@ DoubleInputNode::DoubleInputNode() :
 
         connect(overallW, SIGNAL(valueChanged(double)),
                 this, SLOT(onWidgetValueChanges(double)));
-        connect(overallW, &DoubleInputWidget::sliderReleased,
-                this, &Node::triggerNodeEvaluation);
 
         connect(overallW, &DoubleInputWidget::onMinLabelChanged,
                 this, onMinLabelChanged);
@@ -153,12 +154,16 @@ void
 DoubleInputNode::setValue(double value)
 {
     auto prop = static_cast<GtDoubleProperty*>(m_value.get());
-    prop->setVal(value);
+    if (prop->getVal() != value)
+    {
+        prop->setVal(value);
+        emit triggerNodeEvaluation();
+    }
 }
 
 void
 DoubleInputNode::eval()
-{
+{   
     setNodeData(m_out, std::make_shared<DoubleData>(value()));
 }
 

--- a/src/intelli/node/propertyinput/intinputnode.cpp
+++ b/src/intelli/node/propertyinput/intinputnode.cpp
@@ -68,10 +68,10 @@ IntInputNode::IntInputNode() :
         auto base = makeBaseWidget();
 
         auto overallW = new IntegerInputWidget(value(),
-                                                 m_min.getVal(),
-                                                 m_max.getVal(),
-                                                 base.get(),
-                                                 t);
+                                               m_min.getVal(),
+                                               m_max.getVal(),
+                                               base.get(),
+                                               t);
 
         base->layout()->addWidget(overallW);
 
@@ -102,8 +102,11 @@ IntInputNode::IntInputNode() :
 
         auto onValueLabelChanged = [=](int newVal)
         {
-            if (value() != newVal) setValue(newVal);
-            emit triggerNodeEvaluation();
+            if (value() != newVal)
+            {
+                setValue(newVal);
+                emit triggerNodeEvaluation();
+            }
         };
 
         auto onDisplyModeChanged = [=]()
@@ -113,9 +116,6 @@ IntInputNode::IntInputNode() :
 
         connect(overallW, SIGNAL(valueChanged(int)),
                 this, SLOT(onWidgetValueChanges(int)));
-        connect(overallW, &IntegerInputWidget::sliderReleased,
-                this, &Node::triggerNodeEvaluation);
-
         connect(overallW, &IntegerInputWidget::onMinLabelChanged,
                 this, onMinLabelChanged);
         connect(overallW, &IntegerInputWidget::onMaxLabelChanged,
@@ -154,7 +154,12 @@ void
 IntInputNode::setValue(int value)
 {
     auto prop = static_cast<GtIntProperty*>(m_value.get());
-    prop->setVal(value);
+
+    if (prop->getVal() != value)
+    {
+        prop->setVal(value);
+        emit triggerNodeEvaluation();
+    }
 }
 
 void


### PR DESCRIPTION
Cleanup of some triggers for evaluation to avoid evaluation for not unchanged values