### PR TITLE
Resolve: "Graph execution sometimes stuck in infinite loop"

### DIFF
--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -323,7 +323,7 @@ GraphExecutionModel::isNodeEvaluated(NodeUuid const& nodeUuid) const
 bool
 GraphExecutionModel::isEvaluating() const
 {
-    return !m_evaluatingNodes.empty();
+    return !m_evaluatingNodes.empty() || m_isEvaluatingQueue;
 }
 
 bool

--- a/src/intelli/graphexecmodel.h
+++ b/src/intelli/graphexecmodel.h
@@ -355,6 +355,8 @@ private:
     /// indicator if the exec model is currently beeing modified and thus
     /// should halt execution
     int m_modificationCount = 0;
+    /// indicator if queue is currently being evaluated
+    bool m_isEvaluatingQueue = false;
 
     void beginReset();
 

--- a/src/intelli/private/graphexecmodel_impl.h
+++ b/src/intelli/private/graphexecmodel_impl.h
@@ -1407,6 +1407,14 @@ struct GraphExecutionModel::Impl
     {
         if (model.m_queuedNodes.empty()) return false;
 
+        // queue should be evalauted only once at a time
+        if (model.m_isEvaluatingQueue) return false;
+
+        model.m_isEvaluatingQueue = true;
+        auto finally = gt::finally([&model](){
+            model.m_isEvaluatingQueue = false;
+        });
+
         INTELLI_LOG_SCOPE(model)
             << "evaluating next in queue:"
             << std::vector<NodeUuid>{model.m_queuedNodes.begin(), model.m_queuedNodes.end()} << "...";

--- a/src/intelli/private/graphexecmodel_impl.h
+++ b/src/intelli/private/graphexecmodel_impl.h
@@ -1431,7 +1431,8 @@ struct GraphExecutionModel::Impl
         // when evaluating a node
         for (size_t idx = 0; idx < model.m_queuedNodes.size();)
         {
-            auto iter = model.m_queuedNodes.begin() + idx;
+            auto iter = model.m_queuedNodes.begin();
+            std::advance(iter, idx);
             auto const& nodeUuid = *iter;
 
             auto item = findData(model, nodeUuid);


### PR DESCRIPTION
Closes  #203.

The code evaluating the queued nodes had the potential to enter a infinite loop. This issue was fixed. 