### PR TITLE
Resolve: "Crash while grouping nodes with auto evaluation enabled"

### DIFF
--- a/src/intelli/graph.cpp
+++ b/src/intelli/graph.cpp
@@ -839,7 +839,6 @@ Graph::resetGlobalConnectionModel()
 {
     m_global->clear();
     Impl::repopulateGlobalConnectionModel(*this);
-    debug(*this);
 }
 
 void

--- a/src/intelli/graph.cpp
+++ b/src/intelli/graph.cpp
@@ -495,7 +495,7 @@ Graph::appendNode(std::unique_ptr<Node> node, NodeIdPolicy policy)
     }
 
     // register node in local model
-    m_local.insert(node->id(), node.get() );
+    m_local.insert(node->id(), node.get());
 
     // register node in global model if not present already (avoid overwrite)
     NodeUuid const& nodeUuid = node->uuid();
@@ -835,6 +835,14 @@ Graph::initInputOutputProviders()
 }
 
 void
+Graph::resetGlobalConnectionModel()
+{
+    m_global->clear();
+    Impl::repopulateGlobalConnectionModel(*this);
+    debug(*this);
+}
+
+void
 Graph::eval()
 {
     for (auto& port : ports(PortType::Out))
@@ -887,7 +895,7 @@ Graph::updateGlobalConnectionModel(std::shared_ptr<GlobalConnectionModel> const&
     m_global = ptr;
 
     // apply recursively
-    for (auto& subgraph : graphNodes())
+    for (Graph* subgraph : graphNodes())
     {
         subgraph->updateGlobalConnectionModel(ptr);
     }

--- a/src/intelli/graph.h
+++ b/src/intelli/graph.h
@@ -400,6 +400,12 @@ public:
      */
     void initInputOutputProviders();
 
+    /**
+     * @brief Resets the global connection model. This might be necessary
+     * because NodeUuids have changed.
+     */
+    void resetGlobalConnectionModel();
+
     struct EndModificationFunctor
     {
         inline void operator()() const noexcept

--- a/src/intelli/graphconnectionmodel.h
+++ b/src/intelli/graphconnectionmodel.h
@@ -847,6 +847,8 @@ public:
     iterator insert(key_type const& key, value_type const& value) { return m_data.insert(key, value); }
     void insert(ConnectionModel_t const& other) { m_data.insert(other.m_data); }
 
+    void clear() { m_data.clear(); }
+
     iterator erase(iterator iter) { return m_data.erase(iter); }
     iterator erase(const_iterator iter) { return m_data.erase(iter); }
 

--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -711,6 +711,11 @@ GraphExecutionModel::onNodeAppended(Node* node)
     // append subgraph recursively
     if (auto* subgraph = qobject_cast<Graph*>(node))
     {
+        // avoid auto evaluating nodes if graph has not been appended fully
+        m_modificationCount++;
+        auto finally = gt::finally([this](){ m_modificationCount--; });
+        Q_UNUSED(finally);
+
         setupConnections(*subgraph);
 
         auto const& nodes = subgraph->nodes();
@@ -745,7 +750,7 @@ GraphExecutionModel::onNodeAppended(Node* node)
     }, Qt::DirectConnection);
 
     // auto evaluate if necessary
-    Impl::rescheduleAutoEvaluatingNodes(*this);
+    if (!isBeingModified()) Impl::rescheduleAutoEvaluatingNodes(*this);
 }
 
 void

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -699,6 +699,8 @@ GraphScene::pasteObjects()
     if (!dummy) return;
 
     dummy->newUuid(true);
+    dummy->resetGlobalConnectionModel();
+
     auto const& srcNodes = dummy->nodes();
     auto const& srcConnections = dummy->connections();
 

--- a/src/intelli/private/graphexecmodel_impl.h
+++ b/src/intelli/private/graphexecmodel_impl.h
@@ -859,7 +859,7 @@ struct GraphExecutionModel::Impl
     removeEvaluatedNodes(GraphExecutionModel& model, std::vector<NodeUuid>& nodes)
     {
         nodes.erase(std::remove_if(nodes.begin(), nodes.end(), [&model](const auto& uuid) {
-            auto item = findData(model, uuid);
+            auto item = findData(model, uuid, evaluteNodeError);
             assert(item);
             return item.isEvaluated();
         }), nodes.end());


### PR DESCRIPTION
Closes #210

The reason for the crash was twofolds:

First issue:
1. if a subgraph was copied and pasted all of its subnodes were assigned new UUIDs. This must be done to avoid appending the same node with the same UUID twice.
2. When assigning the new UUIDs the temporary graph has not updated its global connection model (which uses UUIDs to refernce nodes instead)
3. The connection model was thus outdated/invalid which lead to hard to trace errors/inconsistencies as it contained nodes and connections that did not exist

Second issue:
1. the graph node was appended to the root graph
5. when a graph node is appended the exec model first registers all nodes of the subgraph (here input/output provider)
6. once a node is appended the exec model attempts to execute the node
7. at this point the subgraph itself was not registered and was thus not found when attempting to execute the input provider resulting in a null pointer dereference ... 💣💥

The first issue was resolved by updating/resetting the global connection model of the temporary subgraph before merging. This should fix a few inconsistencies where subgraphs were not evaluating eventhough everything looked fine.

The second issue could be fixed by reordering the logic. First the subgraph node is appended, then all child nodes of the subgraph. Only once all subnodes have been appended the newly added nodes are executed when auto evaluation is enabled.