### PR TITLE
Hide size and position properties of nodes in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Major refactoring of the graph execution model. Now only one exec model is used to manage and evaluate a graph hierarchy, improving the handling of nested graphs and fixing unhandled edge cases. Additionally the future-object returned by the exec model is now far more flexible and user friendly, allowing above else the registration of callback functions. - #112
+- IntelliGraph specific compile flags were renamed; node's size and position properties are now always hidden unless the associated compiler flag was set. - #205
 
 ### Fixed
 - Fixed error when creating and loading a project with an empty IntelliGraph package in GTlab 2.1.0 - #193

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,16 +8,20 @@ set(CMAKE_DEBUG_POSTFIX -d)
 set(INTELLIGRAPH_VERSION 0.12.0)
 
 option(
-    _DEBUG_NODE_GRAPHICS
+    INTELLIGRAPH_DEBUG_NODE_GRAPHICS
     "Draws debugging information into the scene to show bounds of node objects" OFF
 )
 option(
-    _DEBUG_CONNECTION_GRAPHICS
+    INTELLIGRAPH_DEBUG_CONNECTION_GRAPHICS
     "Draws debugging information into the scene to show bounds of connection objects" OFF
 )
 option(
-    _DEBUG_NODE_EXECUTION
+    INTELLIGRAPH_DEBUG_NODE_EXECUTION
     "Logs additional debugging information when execution graphs" OFF
+)
+option(
+    INTELLIGRAPH_DEBUG_NODE_PROPERTIES
+    "SHows node properties in property dock widget" OFF
 )
 
 set(PUBLIC_HEADERS
@@ -224,19 +228,24 @@ target_compile_definitions(GTlabIntelliGraph PRIVATE
     GT_LOG_USE_QT_BINDINGS # enable Qt operator<< for logging
 )
 
-if (_DEBUG_NODE_GRAPHICS)
+if (INTELLIGRAPH_DEBUG_NODE_GRAPHICS)
     target_compile_definitions(GTlabIntelliGraph PRIVATE
         GT_INTELLI_DEBUG_NODE_GRAPHICS
     )
 endif()
-if (_DEBUG_CONNECTION_GRAPHICS)
+if (INTELLIGRAPH_DEBUG_CONNECTION_GRAPHICS)
     target_compile_definitions(GTlabIntelliGraph PRIVATE
         GT_INTELLI_DEBUG_CONNECTION_GRAPHICS
     )
 endif()
-if (_DEBUG_NODE_EXECUTION)
+if (INTELLIGRAPH_DEBUG_NODE_EXECUTION)
     target_compile_definitions(GTlabIntelliGraph PRIVATE
         GT_INTELLI_DEBUG_NODE_EXEC
+    )
+endif()
+if (INTELLIGRAPH_DEBUG_NODE_PROPERTIES)
+    target_compile_definitions(GTlabIntelliGraph PRIVATE
+        GT_INTELLI_DEBUG_NODE_PROPERTIES
     )
 endif()
 

--- a/src/intelli/node.cpp
+++ b/src/intelli/node.cpp
@@ -62,11 +62,14 @@ Node::Node(QString const& modelName, GtObject* parent) :
     pimpl->sizeWidth.setReadOnly(true);
     pimpl->sizeHeight.setReadOnly(true);
 
+#ifndef GT_INTELLI_DEBUG_NODE_PROPERTIES
     bool hide = !gtApp || !gtApp->devMode();
-    pimpl->posX.hide(hide);
-    pimpl->posY.hide(hide);
-    pimpl->sizeWidth.hide(hide);
-    pimpl->sizeHeight.hide(hide);
+    pimpl->id.hide(hide);
+    pimpl->posX.hide(true);
+    pimpl->posY.hide(true);
+    pimpl->sizeWidth.hide(true);
+    pimpl->sizeHeight.hide(true);
+#endif
 
     setCaption(modelName);
     


### PR DESCRIPTION
hid size and position properties of nodes, renamed intelligraph specific compiler flags