### PR TITLE
Fixed propagation of node evaluation failure if node is executed in another thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Major refactoring of the graph execution model. Now only one exec model is used to manage and evaluate a graph hierarchy, improving the handling of nested graphs and fixing unhandled edge cases. Additionally the future-object returned by the exec model is now far more flexible and user friendly, allowing above else the registration of callback functions. - #112
 - IntelliGraph specific compile flags were renamed; node's size and position properties are now always hidden unless the associated compiler flag was set. - #205
 
+
 ### Fixed
 - Fixed error when creating and loading a project with an empty IntelliGraph package in GTlab 2.1.0 - #193
 - Fixed potential crashes when deletiing instances of `ObjectData` that were created in a separate thread. - #112
 - Fixed port captions spanning multiple words being truncated. - #212
 - The graph view should now remeber more consistently whether a graph should be auto-evaluated. - #112
+- If a node fails to evaluate all successor nodes are invalidated and marked as failed as well. - #221
 
 ## [0.12.0] - 2024-09-24
 ### Added

--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -635,14 +635,15 @@ GraphExecutionModel::onNodeEvaluated(NodeUuid const& nodeUuid)
 
     if (item->state != NodeEvalState::Invalid)
     {
+        constexpr Impl::SetDataFlags flags = Impl::DontTriggerEvaluation;
+
         // node not failed -> mark outdated outputs as valid
-        constexpr bool triggerEval = false;
         for (auto& port : item->portsOut)
         {
             if (port.data.state == PortDataState::Outdated)
             {
                 port.data.state = PortDataState::Valid;
-                Impl::setNodeData(*this, item, port.portId, port.data, triggerEval);
+                Impl::setNodeData(*this, item,port.portId, port.data, flags);
             }
         }
 

--- a/src/intelli/memory.h
+++ b/src/intelli/memory.h
@@ -116,7 +116,7 @@ inline unique_qptr<T, Deleter> make_unique_qptr(Args&&... args) noexcept
 }
 
 template <typename T, typename Deleter = DeferredDeleter, typename ...Args>
-[[deprecated("use `make_qpointer` instead")]]
+[[deprecated("use `make_unique_qptr` instead")]]
 inline unique_qptr<T, Deleter> make_volatile(Args&&... args) noexcept
 {
     return unique_qptr<T, Deleter>(new T{std::forward<Args>(args)...});


### PR DESCRIPTION
fixed issue with propagation of node evaluation failure if `setNodeData` was called after `evalFailed`