### PR TITLE
Close graph editor if graph is deleted or project is closed

### DIFF
--- a/src/intelli/gui/grapheditor.cpp
+++ b/src/intelli/gui/grapheditor.cpp
@@ -101,9 +101,9 @@ GraphEditor::setData(GtObject* obj)
         return;
     }
 
-    connect(obj, SIGNAL(destroyed(QObject*)), SLOT(deleteLater()));
-
     setObjectName(tr("IntelliGraph Editor") + QStringLiteral(" - ") + graph->caption());
+
+    connect(graph, &QObject::destroyed, this, &QObject::deleteLater);
 }
 
 void

--- a/src/intelli/gui/grapheditor.cpp
+++ b/src/intelli/gui/grapheditor.cpp
@@ -101,6 +101,8 @@ GraphEditor::setData(GtObject* obj)
         return;
     }
 
+    connect(obj, SIGNAL(destroyed(QObject*)), SLOT(deleteLater()));
+
     setObjectName(tr("IntelliGraph Editor") + QStringLiteral(" - ") + graph->caption());
 }
 

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -377,7 +377,7 @@ GraphScene::GraphScene(Graph& graph) :
     connect(m_graph, &Graph::connectionAppended, this, &GraphScene::onConnectionAppended, Qt::DirectConnection);
     connect(m_graph, &Graph::connectionDeleted, this, &GraphScene::onConnectionDeleted, Qt::DirectConnection);
 
-    connect(m_graph, &QObject::destroyed, this, &QObject::deleteLater);
+    setParent(&graph);
 }
 
 GraphScene::~GraphScene() = default;

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -376,6 +376,8 @@ GraphScene::GraphScene(Graph& graph) :
 
     connect(m_graph, &Graph::connectionAppended, this, &GraphScene::onConnectionAppended, Qt::DirectConnection);
     connect(m_graph, &Graph::connectionDeleted, this, &GraphScene::onConnectionDeleted, Qt::DirectConnection);
+
+    connect(m_graph, SIGNAL(destroyed(QObject*)), SLOT(deleteLater()));
 }
 
 GraphScene::~GraphScene() = default;

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -377,7 +377,7 @@ GraphScene::GraphScene(Graph& graph) :
     connect(m_graph, &Graph::connectionAppended, this, &GraphScene::onConnectionAppended, Qt::DirectConnection);
     connect(m_graph, &Graph::connectionDeleted, this, &GraphScene::onConnectionDeleted, Qt::DirectConnection);
 
-    connect(m_graph, SIGNAL(destroyed(QObject*)), SLOT(deleteLater()));
+    connect(m_graph, &QObject::destroyed, this, &QObject::deleteLater);
 }
 
 GraphScene::~GraphScene() = default;

--- a/src/intelli/gui/graphscenemanager.cpp
+++ b/src/intelli/gui/graphscenemanager.cpp
@@ -143,12 +143,20 @@ GraphSceneManager::openGraphByUuid(QString const& graphUuid)
 }
 
 void
-GraphSceneManager::onSceneRemoved(QObject* /*obj*/)
+GraphSceneManager::onSceneRemoved(QObject* scene)
 {
+    // remove null scenes
+    auto const isNull = [](GraphScene* scene) -> bool { return !scene; };
+    m_scenes.erase(std::remove_if(m_scenes.begin(), m_scenes.end(), isNull),
+                   m_scenes.end());
+
+    // current scene is still alive
+    if (currentScene()) return;
+
+    // switch scene
     for (GraphScene* s : m_scenes)
     {
-        if (s)
-        // switch scene
+        assert(s);
         m_view->setScene(*s);
     }
 }

--- a/src/intelli/gui/graphscenemanager.cpp
+++ b/src/intelli/gui/graphscenemanager.cpp
@@ -159,4 +159,6 @@ GraphSceneManager::onSceneRemoved(QObject* scene)
         assert(s);
         m_view->setScene(*s);
     }
+    // no scene
+    if (!currentScene()) m_view->clearScene();
 }

--- a/src/intelli/gui/graphscenemanager.cpp
+++ b/src/intelli/gui/graphscenemanager.cpp
@@ -77,6 +77,9 @@ GraphSceneManager::createScene(Graph& graph)
     connect(scene, &GraphScene::graphNodeDoubleClicked,
             this, &GraphSceneManager::openGraph);
 
+    connect(scene, &GraphScene::destroyed,
+            this, &GraphSceneManager::onSceneRemoved);
+
     // if view has no scene -> set scene
     if (!m_view->nodeScene()) m_view->setScene(*scene);
 
@@ -137,4 +140,15 @@ GraphSceneManager::openGraphByUuid(QString const& graphUuid)
     }
 
     openGraph(graph);
+}
+
+void
+GraphSceneManager::onSceneRemoved(QObject* /*obj*/)
+{
+    for (GraphScene* s : m_scenes)
+    {
+        if (s)
+        // switch scene
+        m_view->setScene(*s);
+    }
 }

--- a/src/intelli/gui/graphscenemanager.h
+++ b/src/intelli/gui/graphscenemanager.h
@@ -75,7 +75,14 @@ public slots:
      */
     void openGraphByUuid(QString const& graphUuid);
 
-    void onSceneRemoved(QObject*);
+private slots:
+
+    /**
+     * @brief Updates scene mamager if a scene was deleted
+     * @param scene Scene that was deleted
+     */
+    void onSceneRemoved(QObject* scene);
+
 private:
 
     QPointer<GraphView> m_view;

--- a/src/intelli/gui/graphscenemanager.h
+++ b/src/intelli/gui/graphscenemanager.h
@@ -75,6 +75,7 @@ public slots:
      */
     void openGraphByUuid(QString const& graphUuid);
 
+    void onSceneRemoved(QObject*);
 private:
 
     QPointer<GraphView> m_view;

--- a/src/intelli/gui/graphview.h
+++ b/src/intelli/gui/graphview.h
@@ -37,7 +37,15 @@ public:
     
     GraphView(QWidget* parent = nullptr);
 
+    /**
+     * @brief Sets the current scene
+     * @param scene Scene
+     */
     void setScene(GraphScene& scene);
+    /**
+     * @brief Clears the current scene
+     */
+    void clearScene();
 
     /// @brief max=0/min=0 indicates infinite zoom in/out
     void setScaleRange(double minimum = 0, double maximum = 0);

--- a/src/intelli/gui/graphviewoverlay.cpp
+++ b/src/intelli/gui/graphviewoverlay.cpp
@@ -204,7 +204,16 @@ void
 GraphViewOverlay::onSceneChanged(GraphScene* scene)
 {
     assert(m_view);
-    if (!scene) return;
+    if (!scene)
+    {
+        m_startAutoEvalBtn->setEnabled(false);
+        m_stopAutoEvalBtn->setEnabled(false);
+        m_snapToGridBtn->setEnabled(false);
+        m_snapToGridBtn->setVisible(false);
+        m_sceneMenu->setEnabled(false);
+        m_viewMenu->setEnabled(false);
+        return;
+    }
 
     auto& graph = scene->graph();
 
@@ -215,6 +224,7 @@ GraphViewOverlay::onSceneChanged(GraphScene* scene)
     m_snapToGridBtn->setEnabled(true);
     m_snapToGridBtn->setVisible(m_view->isGridVisible());
 
+    m_viewMenu->setEnabled(true);
     m_sceneMenu->setEnabled(true);
 
     auto onSnapToGridChanged = [this](){


### PR DESCRIPTION
I added a connection to close the editor. The signal is triggered if the graph is deleted or (as it also deletes the graph) the project is closed.