### PR TITLE
Fixed node evaluation failure not being propagated when connecting to an invalid node

### DIFF
--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -205,6 +205,13 @@ GraphExecutionModel::reset()
 }
 
 void
+GraphExecutionModel::resetTargetNodes()
+{
+    m_targetNodes.clear();
+    m_pendingNodes.clear();
+}
+
+void
 GraphExecutionModel::beginReset()
 {
     assert(m_graph);
@@ -855,6 +862,13 @@ GraphExecutionModel::onConnectionAppended(ConnectionUuid conUuid)
     INTELLI_LOG(*this)
         << tr("Connection appended: updated execution model! ('%1')")
                .arg(toString(conUuid));
+
+    // check if source node is invalid -> propagate invalidation
+    bool isInvalid = itemOut->state == NodeEvalState::Invalid;
+    if (isInvalid)
+    {
+        return Impl::propagateNodeEvaluationFailure(*this, conUuid.inNodeId, itemIn);
+    }
 
     // set node data
     auto data = nodeData(itemOut.node->uuid(), conUuid.outPort);

--- a/src/intelli/graphexecmodel.h
+++ b/src/intelli/graphexecmodel.h
@@ -74,6 +74,12 @@ public:
     void reset();
 
     /**
+     * @brief Resets all nodes that were previously marked for evaluation using
+     * `evaluateGraph` or `evaluateNode`.
+     */
+    void resetTargetNodes();
+
+    /**
      * @brief Returns the node evaluation state of the given node
      * @param nodeUuid Node Uuid of the requested node.
      * @return Node eval state


### PR DESCRIPTION
fixed that a failed evaluation is not being forwarded when connecting to an failed node.

Closes #221 