### PR TITLE
Fix crash when closing GraphEditor or deleting currently open graph

### DIFF
--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -377,7 +377,7 @@ GraphScene::GraphScene(Graph& graph) :
     connect(m_graph, &Graph::connectionAppended, this, &GraphScene::onConnectionAppended, Qt::DirectConnection);
     connect(m_graph, &Graph::connectionDeleted, this, &GraphScene::onConnectionDeleted, Qt::DirectConnection);
 
-    setParent(&graph);
+    connect(m_graph, &Graph::graphAboutToBeDeleted, this, &QObject::deleteLater);
 }
 
 GraphScene::~GraphScene() = default;

--- a/src/intelli/gui/graphscenemanager.cpp
+++ b/src/intelli/gui/graphscenemanager.cpp
@@ -34,6 +34,8 @@ GraphSceneManager::GraphSceneManager(GraphView& view) :
 
 }
 
+GraphSceneManager::~GraphSceneManager() = default;
+
 GraphSceneManager*
 GraphSceneManager::make(GraphView& view)
 {
@@ -69,7 +71,7 @@ GraphSceneManager::createScene(Graph& graph)
     }
 
     // create scene
-    auto scenePtr = make_unique_qptr<GraphScene, DirectDeleter>(graph);
+    auto scenePtr = make_unique_qptr<GraphScene, DeferredDeleter>(graph);
     GraphScene* scene = scenePtr.get();
 
     m_scenes.push_back(std::move(scenePtr));
@@ -154,11 +156,7 @@ GraphSceneManager::onSceneRemoved(QObject* scene)
     if (currentScene()) return;
 
     // switch scene
-    for (GraphScene* s : m_scenes)
-    {
-        assert(s);
-        m_view->setScene(*s);
-    }
-    // no scene
-    if (!currentScene()) m_view->clearScene();
+    m_scenes.empty() ?
+        m_view->clearScene() :
+        m_view->setScene(*m_scenes.back());
 }

--- a/src/intelli/gui/graphscenemanager.h
+++ b/src/intelli/gui/graphscenemanager.h
@@ -33,6 +33,7 @@ class GraphSceneManager : public QObject
 public:
 
     GraphSceneManager(GraphView& view);
+    ~GraphSceneManager();
 
     /**
      * @brief Creates a scene manager object for the view. Ownership is
@@ -87,7 +88,7 @@ private:
 
     QPointer<GraphView> m_view;
 
-    std::vector<unique_qptr<GraphScene, DirectDeleter>> m_scenes;
+    std::vector<unique_qptr<GraphScene, DeferredDeleter>> m_scenes;
 };
 
 } // namespace intelli

--- a/src/intelli/gui/graphstatemanager.cpp
+++ b/src/intelli/gui/graphstatemanager.cpp
@@ -43,6 +43,8 @@ GraphStateManager::GraphStateManager(Graph& graph, GraphView& view) :
     }
 }
 
+GraphStateManager::~GraphStateManager() = default;
+
 GraphStateManager*
 GraphStateManager::make(Graph& graph, GraphView &view)
 {

--- a/src/intelli/gui/graphstatemanager.h
+++ b/src/intelli/gui/graphstatemanager.h
@@ -36,6 +36,7 @@ class GraphStateManager : public QObject
 public:
 
     GraphStateManager(Graph& graph, GraphView& view);
+    ~GraphStateManager();
 
     /**
      * @brief Creates a state manager instance for view object. Ownership is

--- a/src/intelli/gui/graphview.cpp
+++ b/src/intelli/gui/graphview.cpp
@@ -148,6 +148,8 @@ GraphView::GraphView(QWidget* parent) :
     clearSelectionAction->setShortcut(Qt::Key_Escape);
 }
 
+GraphView::~GraphView() = default;
+
 void
 GraphView::setScene(GraphScene& scene)
 {

--- a/src/intelli/gui/graphview.h
+++ b/src/intelli/gui/graphview.h
@@ -36,6 +36,7 @@ public:
     };
     
     GraphView(QWidget* parent = nullptr);
+    ~GraphView();
 
     /**
      * @brief Sets the current scene

--- a/src/intelli/gui/graphviewoverlay.cpp
+++ b/src/intelli/gui/graphviewoverlay.cpp
@@ -141,7 +141,7 @@ GraphViewOverlay::GraphViewOverlay(GraphView& view) :
     m_stopAutoEvalBtn->setVisible(false);
 
     connect(m_startAutoEvalBtn, &QPushButton::clicked,
-        this, std::bind(updateAutoEvaluation, true));
+            this, std::bind(updateAutoEvaluation, true));
     connect(m_stopAutoEvalBtn, &QPushButton::clicked,
             this, std::bind(updateAutoEvaluation, false));
 
@@ -193,6 +193,8 @@ GraphViewOverlay::GraphViewOverlay(GraphView& view) :
         onSceneChanged(scene);
     }
 }
+
+GraphViewOverlay::~GraphViewOverlay() = default;
 
 GraphViewOverlay*
 GraphViewOverlay::make(GraphView& view)

--- a/src/intelli/gui/graphviewoverlay.h
+++ b/src/intelli/gui/graphviewoverlay.h
@@ -37,6 +37,7 @@ class GraphViewOverlay : public QHBoxLayout
 public:
 
     GraphViewOverlay(GraphView& view);
+    ~GraphViewOverlay();
 
     /**
      * @brief Creates an overlay widget ontop the view object. Ownership is

--- a/src/intelli/private/utils.h
+++ b/src/intelli/private/utils.h
@@ -25,6 +25,7 @@
 #include <gt_logstream.h>
 
 #include <QRegExpValidator>
+#include <QTimer>
 
 #include <algorithm>
 
@@ -173,11 +174,13 @@ struct SetupStateHelper
 
     /**
      * @brief Finalizes the state creation by triggering the `onStateChanged`
-     * slot.
+     * slot in the next event cycle.
      */
     GtState* finalize()
     {
-        emit state->valueChanged(state->getValue());
+        QTimer::singleShot(0, [state = this->state](){
+            emit state->valueChanged(state->getValue());
+        });
         return state;
     }
 };


### PR DESCRIPTION
Fixes crash when closing graph editor or when deleting the active graph and thus switching the scene. 

Closes #233

The main two issues where that the scenes were deleted before all events were served (when closing graph editor) and that the state update somehow triggered a setter slot on a **deleted** scene object (for what ever reason the signal-slot connection is only deleted just after...). The latter issue could be fixed by triggering the sate update in the next event cycle.