### PR TITLE
[Clang] Fix build error due to non constant Template Parameter

### DIFF
--- a/src/intelli/graphconnectionmodel.h
+++ b/src/intelli/graphconnectionmodel.h
@@ -413,8 +413,8 @@ struct ConnectionData
             if (i.iter == i.end && i.type == PortType::In)
             {
                 auto& p = i.ptr->ports(PortType::Out);
-                i.iter = detail::begin_iterator<i.IsReversed, container_type>{}(p);
-                i.end  = detail::end_iterator<i.IsReversed, container_type>{}(p);
+                i.iter = detail::begin_iterator<Base::IsReversed, container_type>{}(p);
+                i.end  = detail::end_iterator<Base::IsReversed, container_type>{}(p);
                 i.type = PortType::Out;
             }
         }
@@ -483,8 +483,8 @@ struct ConnectionData
 
                     // switch to output side
                     auto& p = i.ptr->ports(PortType::Out);
-                    i.iter = detail::begin_iterator<i.IsReversed, container_type>{}(p);
-                    i.end  = detail::end_iterator<i.IsReversed, container_type>{}(p);
+                    i.iter = detail::begin_iterator<Base::IsReversed, container_type>{}(p);
+                    i.end  = detail::end_iterator<Base::IsReversed, container_type>{}(p);
                     i.type = PortType::Out;
                 }
                 else


### PR DESCRIPTION
Fixed non constant template parameter in connection model. For what ever reason my clang-cmake config (or whatever) did not like accessing a static constexpr of a variable, but demanded to use the class type directly. Maybe its clang specific feature.

clang 18.1.8
cmake 3.31.1
Qt 5.15.16