### PR TITLE
Resolve: "Moving graph nodes from one graph to another leaves connection models in incorrect state"

### DIFF
--- a/src/intelli/exec/detachedexecutor.cpp
+++ b/src/intelli/exec/detachedexecutor.cpp
@@ -48,7 +48,7 @@ int signal_offset(){
 
 #ifdef GT_INTELLI_DEBUG_NODE_EXEC
         gtTrace().verbose()
-            << "[DetachedExecutor]"
+            << utils::logId<DetachedExecutor>()
             << QObject::tr("signal offset for derived nodes of '%1' is %2")
                    .arg(sourceMetaObject->className()).arg(offset);
 #endif
@@ -127,7 +127,7 @@ connectSignals(QVector<SignalSignature> const& signalsToConnect,
         if (signalIndex == -1)
         {
             gtWarning()
-                << "[DetachedExecutor]"
+                << utils::logId<DetachedExecutor>()
                 << QObject::tr("failed to forward signal from clone to source node!")
                 << gt::brackets(signal);
             return {};
@@ -136,7 +136,7 @@ connectSignals(QVector<SignalSignature> const& signalsToConnect,
 
 #ifdef GT_INTELLI_DEBUG_NODE_EXEC
         gtTrace().verbose()
-            << "[DetachedExecutor]"
+            << utils::logId<DetachedExecutor>()
             << QObject::tr("connecting custom signal '%1' of node '%2'")
                    .arg(signal, sourceMetaObject->className());
 #endif
@@ -146,7 +146,7 @@ connectSignals(QVector<SignalSignature> const& signalsToConnect,
                               Qt::QueuedConnection))
         {
             gtWarning()
-                << "[DetachedExecutor]"
+                << utils::logId<DetachedExecutor>()
                 << QObject::tr("failed to connect signal of clone with source node!")
                 << gt::brackets(signal);
             return {};
@@ -188,7 +188,7 @@ DetachedExecutor::onFinished()
 {
     if (!m_node)
     {
-        gtError() << "[DetachedExecutor]"
+        gtError() << utils::logId(this)
                   << tr("Cannot finish transfer of node data! (Invalid node)");
 
         m_destroyed = true;
@@ -204,7 +204,7 @@ DetachedExecutor::onFinished()
 void
 DetachedExecutor::onCanceled()
 {
-    gtError() << "[DetachedExecutor]"
+    gtError() << utils::logId(this)
               << tr("Execution of node '%1' failed!")
                      .arg(m_node ? m_node->objectName() :
                                    QStringLiteral("<null>"));
@@ -215,7 +215,7 @@ DetachedExecutor::onResultReady(int result)
 {
     if (!m_node)
     {
-        gtError() << "[DetachedExecutor]"
+        gtError() << utils::logId(this)
                   << tr("cannot transfer node data! (Invalid node)");
         return;
     }
@@ -227,7 +227,7 @@ DetachedExecutor::onResultReady(int result)
 
 #ifdef GT_INTELLI_DEBUG_NODE_EXEC
     gtTrace().verbose()
-        << "[DetachedExecutor]"
+        << utils::logId(this)
         << tr("collecting data from node '%1' (%2)...")
                .arg(relativeNodePath(*m_node))
                .arg(m_node->id());
@@ -241,7 +241,7 @@ DetachedExecutor::onResultReady(int result)
     auto* model = exec::nodeDataInterface(*m_node);
     if (!model)
     {
-        gtError() << "[DetachedExecutor]"
+        gtError() << utils::logId(this)
                   << tr("failed to transfer node data! (Execution model not found)");
         return;
     }
@@ -252,7 +252,7 @@ DetachedExecutor::onResultReady(int result)
 
     if (!model->setNodeData(nodeUuid, PortType::Out, outData))
     {
-        gtError() << "[DetachedExecutor]"
+        gtError() << utils::logId(this)
                   << tr("failed to transfer node data!");
     }
 
@@ -266,7 +266,7 @@ DetachedExecutor::evaluateNode(Node& node, NodeDataInterface& model)
 {
     if (!canEvaluateNode())
     {
-        gtWarning() << "[DetachedExecutor]"
+        gtWarning() << utils::logId(this)
                     << tr("cannot evaluate node '%1'! (Node is already running)")
                            .arg(node.objectName());
         return false;
@@ -276,9 +276,8 @@ DetachedExecutor::evaluateNode(Node& node, NodeDataInterface& model)
     if (!m_watcher.isFinished())
     {
         gtTrace().verbose()
-            << "[DetachedExecutor]"
-            << tr("reusing executor")
-            << (void*)this;
+            << utils::logId(this)
+            << tr("reusing executor:") << (void*)this;
     }
 #endif
 
@@ -304,15 +303,14 @@ DetachedExecutor::evaluateNode(Node& node, NodeDataInterface& model)
     {
 #ifdef GT_INTELLI_DEBUG_NODE_EXEC
         gtTrace().verbose()
-            << "[DetachedExecutor]"
+            << utils::logId<DetachedExecutor>()
             << tr("beginning evaluation of node '%1' (%2)...")
                    .arg(memento.ident())
                    .arg(nodeUuid);
 #endif
 
         auto const makeError = [nodeUuid](){
-            return QStringLiteral("[DetachedExecutor] ") +
-                   tr("evaluating node %1 failed!").arg(nodeUuid);
+            return tr("evaluating node %1 failed!").arg(nodeUuid);
         };
 
         try{
@@ -323,7 +321,7 @@ DetachedExecutor::evaluateNode(Node& node, NodeDataInterface& model)
             auto* node = clone.get();
             if (!node)
             {
-                gtError() << makeError()
+                gtError() << utils::logId<DetachedExecutor>() << makeError()
                           << tr("(cloning node failed)").arg(memento.ident());
                 return {};
             }
@@ -351,7 +349,7 @@ DetachedExecutor::evaluateNode(Node& node, NodeDataInterface& model)
 
             if (!success)
             {
-                gtError() << makeError()
+                gtError() << utils::logId<DetachedExecutor>() << makeError()
                           << tr("(failed to copy source data)");
                 return {};
             }
@@ -363,13 +361,13 @@ DetachedExecutor::evaluateNode(Node& node, NodeDataInterface& model)
         }
         catch (const std::exception& ex)
         {
-            gtError() << makeError()
+            gtError() << utils::logId<DetachedExecutor>() << makeError()
                       << tr("(caught exception: %1)").arg(ex.what());
             return {};
         }
         catch(...)
         {
-            gtError() << makeError()
+            gtError() << utils::logId<DetachedExecutor>() << makeError()
                       << tr("(caught unkown exception)");
             return {};
         }

--- a/src/intelli/graph.h
+++ b/src/intelli/graph.h
@@ -77,6 +77,8 @@ enum class NodeIdPolicy
 
 /// prints the graph as a mermaid flow chart useful for debugging
 GT_INTELLI_EXPORT void debug(Graph const& graph);
+GT_INTELLI_EXPORT void debug(ConnectionModel const& model);
+GT_INTELLI_EXPORT void debug(GlobalConnectionModel const& model);
 
 template <typename NodeId_t, typename NodeList>
 static bool containsNodeId(NodeId_t const& nodeId, NodeList const& nodes)
@@ -489,11 +491,16 @@ public:
         if (!moveNodes(nodes, targetGraph, policy)) return false;
 
         // reinstantiate internal connections
-        return std::all_of(connectionsToMove.begin(),
+        bool success = std::all_of(connectionsToMove.begin(),
                            connectionsToMove.end(),
                            [&targetGraph](auto const& conUuid){
             return targetGraph.appendConnection(targetGraph.connectionId(conUuid));
         });
+
+//        resetGlobalConnectionModel();
+//        targetGraph.resetGlobalConnectionModel();
+
+        return success;
     }
 
     /**
@@ -514,6 +521,9 @@ public:
         Q_UNUSED(changeCmd);
         Q_UNUSED(changeTargetCmd);
 
+        // NOTE: nodes's iterators may get invalidated if a node is removed
+        // and if nodes's iterators point to the underlying connection models
+        // causing UDB?
         return std::all_of(nodes.begin(), nodes.end(),
                            [this, &targetGraph, policy](auto node){
             return moveNode(get_node_id<NodeId>{}(node), targetGraph, policy);

--- a/src/intelli/graph.h
+++ b/src/intelli/graph.h
@@ -497,9 +497,6 @@ public:
             return targetGraph.appendConnection(targetGraph.connectionId(conUuid));
         });
 
-//        resetGlobalConnectionModel();
-//        targetGraph.resetGlobalConnectionModel();
-
         return success;
     }
 
@@ -694,6 +691,9 @@ private:
     std::shared_ptr<GlobalConnectionModel> m_global = nullptr;
     /// indicator if the connection model is currently beeing modified
     int m_modificationCount = 0;
+    /// flag indicating that the connection model should be reset once
+    /// the graph is no longer being modified
+    bool m_resetAfterModification = false;
 
     /**
      * @brief Whether this model is currently undergoing modification.

--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -25,14 +25,19 @@ GraphExecutionModel::GraphExecutionModel(Graph& graph) :
 {
     if (graph.parentGraph())
     {
-        gtError() << tr("A graph execution model should only be added to the root Graph!");
+        gtError() << utils::logId(this->graph())
+                  << utils::logId(*this)
+                  << tr("graph %1 is not a root graph!")
+                         .arg(graph.objectName());
         m_modificationCount++; // deactivate this exec model
     }
 
     if (auto* exec = graph.findDirectChild<GraphExecutionModel*>())
     if (exec != this)
     {
-        gtError() << tr("The graph %1 already has a graph execution model associated!")
+        gtError() << utils::logId(this->graph())
+                  << utils::logId(*this)
+                  << tr("graph %1 already has a graph execution model associated!")
                         .arg(graph.objectName());
     }
 
@@ -57,8 +62,9 @@ GraphExecutionModel::GraphExecutionModel(Graph& graph) :
         Node const* node = this->graph().globalConnectionModel().node(nodeUuid);
         if (node)
         {
-            gtInfo()
-                << gt::quoted(this->graph().caption(), "", ":")
+            gtInfo().medium()
+                << utils::logId(this->graph())
+                << utils::logId(*this)
                 << tr("node '%1' (%2) evaluated!")
                        .arg(relativeNodePath(*node))
                        .arg(node->id());
@@ -71,7 +77,8 @@ GraphExecutionModel::GraphExecutionModel(Graph& graph) :
         if (node)
         {
             gtWarning()
-                << gt::quoted(this->graph().caption(), "", ":")
+                << utils::logId(this->graph())
+                << utils::logId(*this)
                 << tr("node '%1' (%2) failed to evaluate!")
                        .arg(relativeNodePath(*node))
                        .arg(node->id());
@@ -81,16 +88,18 @@ GraphExecutionModel::GraphExecutionModel(Graph& graph) :
 
     connect(this, &GraphExecutionModel::internalError,
             this, [this](){
-            gtWarning()
-                << gt::quoted(this->graph().caption(), "", ":")
+        gtWarning()
+                << utils::logId(this->graph())
+                << utils::logId(*this)
                 << tr("intenral error occured!");
     }, Qt::DirectConnection);
 
     connect(this, &GraphExecutionModel::graphStalled,
             this, [this](){
         gtWarning()
-            << gt::quoted(this->graph().caption(), "", ":")
-            << tr("graph stalled!");
+                << utils::logId(this->graph())
+                << utils::logId(*this)
+                << tr("graph stalled!");
     }, Qt::DirectConnection);
 
     reset();
@@ -545,7 +554,8 @@ GraphExecutionModel::nodeEvaluationStarted(NodeUuid const& nodeUuid)
     if (!item)
     {
         gtError()
-            << graph().objectName() + QStringLiteral(":")
+            << utils::logId(this->graph())
+            << utils::logId(*this)
             << tr("Failed to mark node '%1' as evaluating! (node not found)")
                    .arg(nodeUuid);
         return;
@@ -579,7 +589,8 @@ GraphExecutionModel::setNodeEvaluationFailed(NodeUuid const& nodeUuid)
     if (!item)
     {
         gtError()
-            << graph().objectName() + QStringLiteral(":")
+            << utils::logId(this->graph())
+            << utils::logId(this)
             << tr("Failed to mark node '%1' as failed! (node not found)")
                    .arg(nodeUuid);
         return;
@@ -594,10 +605,12 @@ GraphExecutionModel::onNodeEvaluated(NodeUuid const& nodeUuid)
     auto item = Impl::findData(*this, nodeUuid);
     if (!item)
     {
-        gtError() << graph().objectName() + QStringLiteral(": ")
-                  << tr("Node %1 has been evaluated, "
-                        "but was not found in the model!")
-                         .arg(nodeUuid);
+        gtError()
+            << utils::logId(this->graph())
+            << utils::logId(*this)
+            << tr("Node %1 has been evaluated, "
+                  "but was not found in the model!")
+                   .arg(nodeUuid);
         return emit internalError(QPrivateSignal());
     }
 
@@ -768,7 +781,8 @@ GraphExecutionModel::onNodeDeleted(Graph* graph, NodeId nodeId)
     assert(graph);
 
     auto const makeError = [](Graph const& graph){
-        return graph.objectName() + QStringLiteral(": ") +
+        return utils::logId(graph) + QChar{' '} +
+               utils::logId<GraphExecutionModel>() + QChar{' '} +
                tr("Node deleted - cannot update execution model") + ',';
     };
 
@@ -801,7 +815,8 @@ GraphExecutionModel::onNodePortInserted(NodeId nodeId, PortType type, PortIndex 
     assert(idx  != invalid<PortIndex>());
 
     auto const makeError = [](Graph const& graph){
-        return graph.objectName() + QStringLiteral(": ") +
+        return utils::logId(graph) + QChar{' '} +
+               utils::logId<GraphExecutionModel>() + QChar{' '} +
                tr("Port inserted: cannot update execution model") + ',';
     };
 
@@ -827,7 +842,8 @@ GraphExecutionModel::onNodePortAboutToBeDeleted(NodeId nodeId, PortType type, Po
     assert(idx  != invalid<PortIndex>());
 
     auto const makeError = [](Graph const& graph){
-        return graph.objectName() + QStringLiteral(": ") +
+        return utils::logId(graph) + QChar{' '} +
+               utils::logId<GraphExecutionModel>() + QChar{' '} +
                tr("Port deleted: cannot update execution model") + ',';
     };
 
@@ -849,7 +865,8 @@ GraphExecutionModel::onConnectionAppended(ConnectionUuid conUuid)
     assert(conUuid.isValid());
 
     auto const makeError = [](Graph const& graph){
-        return graph.objectName() + QStringLiteral(": ") +
+        return utils::logId(graph) + QChar{' '} +
+               utils::logId<GraphExecutionModel>() + QChar{' '} +
                tr("Connection appended: cannot update execution model") + ',';
     };
 
@@ -881,7 +898,8 @@ GraphExecutionModel::onConnectionDeleted(ConnectionUuid conUuid)
     assert(conUuid.isValid());
 
     auto const makeError = [](Graph const& graph){
-        return graph.objectName() + QStringLiteral(": ") +
+        return utils::logId(graph) + QChar{' '} +
+               utils::logId<GraphExecutionModel>() + QChar{' '} +
                tr("Connection deleted: cannot update execution model") + ',';
     };
 
@@ -909,7 +927,8 @@ GraphExecutionModel::onGraphDeleted()
     if (!graph)
     {
         gtError()
-            << this->graph().objectName() + QStringLiteral(":")
+            << utils::logId(this->graph())
+            << utils::logId(*this)
             << tr("A graph node has been delted, "
                   "but its object was not found!");
         return;

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -289,7 +289,10 @@ makeDraftConnection(GraphScene& scene,
     QPointF oldEndPoint = getEndPoint(conId, type);
 
     // delete old connection
-    bool success = gtDataModel->deleteFromModel(scene.graph().findConnection(conId));
+    auto oldConnection = scene.graph().findConnection(conId);
+    assert(oldConnection);
+
+    bool success = gtDataModel->deleteFromModel(oldConnection);
     assert(success);
 
     auto outNode = scene.nodeObject(conId.outNodeId);
@@ -1599,7 +1602,14 @@ GraphScene::onConnectionDeleted(ConnectionId conId)
         return e.conId == conId;
     });
 
-    if (iter != m_connections.end()) m_connections.erase(iter);
+    if (iter == m_connections.end())
+    {
+        gtError() << utils::logId(this)
+                  << tr("Failed to remove connection:") << conId;
+        return;
+    }
+
+    m_connections.erase(iter);
 
     // update in and out node
     auto* inNode  = nodeObject(conId.inNodeId);

--- a/src/intelli/private/graph_impl.h
+++ b/src/intelli/private/graph_impl.h
@@ -220,6 +220,34 @@ struct Graph::Impl
         return true;
     }
 
+    static inline bool
+    moveGlobalConnections(Graph& targetGraph,
+                                  std::shared_ptr<GlobalConnectionModel>& targetModel,
+                                  std::shared_ptr<GlobalConnectionModel>& sourceModel)
+    {
+        for (Node* node : targetGraph.m_local.iterateNodes())
+        {
+            if (auto* subgraph = qobject_cast<Graph*>(node))
+            {
+                subgraph->m_global = targetModel;
+                if (!moveGlobalConnections(*subgraph, targetModel, sourceModel))
+                {
+                    return false;
+                }
+            }
+
+            auto iter = sourceModel->find(node->uuid());
+            if (iter == sourceModel->end()) return false;
+
+            auto i = targetModel->insert(node->uuid(), node);
+            i->predecessors = std::move(iter->predecessors);
+            i->successors = std::move(iter->successors);
+            sourceModel->erase(iter);
+        }
+
+        return true;
+    }
+
     /// recursively updates the global connection model of `graph` by inserting
     /// nodes and setting connections
     static inline void
@@ -237,6 +265,7 @@ struct Graph::Impl
         // recurisvely append nodes and connections
         for (Graph* subgraph : graph.graphNodes())
         {
+            assert(graph.m_global.get() == subgraph->m_global.get());
             repopulateGlobalConnectionModel(*subgraph);
         }
         // append connections of this graph
@@ -248,6 +277,11 @@ struct Graph::Impl
                 assert(connection);
                 Node* targetNode = graph.findNode(conId.inNodeId);
                 assert(targetNode);
+
+                connect(connection, &QObject::destroyed,
+                        &graph, Impl::ConnectionDeleted(&graph, conId),
+                        Qt::DirectConnection);
+
                 graph.appendGlobalConnection(connection, conId, *targetNode);
             }
         }
@@ -309,7 +343,8 @@ struct Graph::Impl
             PortInfo* port = node->port(portId);
             if (!port)
             {
-                gtWarning() << tr("Failed to update connections of changed "
+                gtWarning() << utils::logId(*graph)
+                            << tr("Failed to update connections of changed "
                                   "portId %1 node %2!")
                                    .arg(portId).arg(nodeId);
                 return;
@@ -374,7 +409,8 @@ struct Graph::Impl
             auto localIter = graph->m_local.find(nodeId);
             if (localIter == graph->m_local.end())
             {
-                gtWarning() << tr("Failed to delete node") << nodeId
+                gtWarning() << utils::logId(*graph)
+                            << tr("Failed to delete node") << nodeId
                             << tr("(node was not found!)");
                 return;
             }
@@ -385,7 +421,8 @@ struct Graph::Impl
             auto globalIter = graph->m_global->find(nodeUuid);
             if (globalIter == graph->m_global->end())
             {
-                gtWarning() << tr("Failed to delete node") << nodeId
+                gtWarning() << utils::logId(*graph)
+                            << tr("Failed to delete node") << nodeId
                             << tr("(node was not found in global model!)");
                 return;
             }
@@ -445,7 +482,9 @@ struct Graph::Impl
 
             if (targetNode == model->end() || sourceNode == model->end())
             {
-                gtWarning() << tr("Failed to delete connection %1").arg(toString(conId))
+                gtWarning() << utils::logId(*graph)
+                            << tr("Failed to delete connection %1")
+                                   .arg(toString(conId))
                             << tr("(in-node entry %1, out-node entry %2!)")
                                    .arg(targetNode != model->end() ? "found" : "not found")
                                    .arg(sourceNode != model->end() ? "found" : "not found");
@@ -462,7 +501,9 @@ struct Graph::Impl
 
             if (inIdx < 0 || outIdx < 0)
             {
-                gtWarning() << tr("Failed to delete connection %1").arg(toString(conId))
+                gtWarning() << utils::logId(*graph)
+                            << tr("Failed to delete connection %1")
+                                   .arg(toString(conId))
                             << tr("(in-connection %1, out-connection %2!)")
                                    .arg(inIdx  >= 0 ? "found" : "not found")
                                    .arg(outIdx >= 0 ? "found" : "not found");

--- a/src/intelli/private/graphexecmodel_impl.h
+++ b/src/intelli/private/graphexecmodel_impl.h
@@ -50,9 +50,10 @@ inline QString makeIndentation(int indent)
 
 // helper macros for more legible output
 #define INTELLI_LOG_IMPL(MODEL, INDENT) \
-    (MODEL).graph().objectName() + QChar{':'} + makeIndentation(INDENT)
+    utils::logId((MODEL).graph()) + QChar{' '} + \
+    utils::logId(MODEL) + makeIndentation(INDENT)
 #define INTELLI_LOG_SCOPE(MODEL) \
-           auto undo_indentation__ = gt::finally([&](){ getIndentation((MODEL))--; }); \
+    auto undo_indentation__ = gt::finally([&](){ getIndentation((MODEL))--; }); \
     gtTrace().verbose() << INTELLI_LOG_IMPL(MODEL, getIndentation((MODEL))++)
 #define INTELLI_LOG(MODEL) \
     gtTrace().verbose() << INTELLI_LOG_IMPL(MODEL, getIndentation((MODEL)))
@@ -75,25 +76,25 @@ using MakeErrorFunction = QString(*)(Graph const&);
 
 inline QString setNodeDataError(Graph const& graph)
 {
-    return graph.objectName() + QStringLiteral(": ") +
+    return utils::logId(graph) + utils::logId<GraphExecutionModel>();
            QObject::tr("failed to set node data") + ',';
 }
 
 inline QString getNodeDataError(Graph const& graph)
 {
-    return graph.objectName() + QStringLiteral(": ") +
+    return utils::logId(graph) + utils::logId<GraphExecutionModel>();
            QObject::tr("failed to access node data") + ',';
 }
 
 inline QString evaluteNodeError(Graph const& graph)
 {
-    return graph.objectName() + QStringLiteral(": ") +
+    return utils::logId(graph) +utils::logId<GraphExecutionModel>();
            QObject::tr("failed to evaluate node") + ',';
 }
 
 inline QString autoEvaluteNodeError(Graph const& graph)
 {
-    return graph.objectName() + QStringLiteral(": ") +
+    return utils::logId(graph) + utils::logId<GraphExecutionModel>();
            QObject::tr("failed to auto evaluate node") + ',';
 }
 
@@ -447,8 +448,7 @@ struct GraphExecutionModel::Impl
             bool valid =
                 std::all_of(entry->portsIn.begin(), entry->portsIn.end(),
                             [conData, this](PortDataItem const& entry){
-                // TODO: check only predecessors
-                bool isConnected = !conData->iterate(entry.portId).empty();
+                bool isConnected = conData->hasConnections(entry.portId, PortType::In);
                 bool isPortDataValid = entry.data.state == PortDataState::Valid;
 
                 auto* port = node->port(entry.portId);

--- a/src/intelli/private/utils.h
+++ b/src/intelli/private/utils.h
@@ -18,6 +18,7 @@
 #include <gt_statehandler.h>
 #include <gt_inputdialog.h>
 #include <gt_icons.h>
+#include <gt_utilities.h>
 #include <gt_qtutilities.h>
 #include <gt_datamodel.h>
 #include <gt_regexp.h>
@@ -133,6 +134,30 @@ erase(List& list, T const& t)
     }
     return false;
 }
+
+/// Helper function that returns the path of the node as a formated string for
+/// logging
+inline QString
+logId(Node const& node)
+{
+    return gt::quoted(relativeNodePath(node), "[", "]");
+}
+
+/// Helper function that returns the class name of the template parameter as a
+/// formated string for logging
+template<typename T>
+inline QString logId()
+{
+    static QString str = QString{T::staticMetaObject.className()}.remove("intelli::");
+    return gt::quoted(str, "[", "]");
+}
+
+/// Helper function to deduce class name from argument and return a formated
+/// string for logging
+template<typename T,
+         typename U = std::remove_cv_t<std::remove_reference_t<std::remove_pointer_t<T>>>,
+         std::enable_if_t<!std::is_base_of<Node, U>::value, bool> = true>
+inline QString logId(T const&) { return logId<U>(); }
 
 /// helper struct to make state creation more explicit and ledgible
 template <typename GetValue>
@@ -289,7 +314,6 @@ inline void restrictRegExpWithSiblingsNames(GtObject& obj,
 
     defaultRegExp = QRegExp(pattern);
 }
-
 
 } // namespace utils
 

--- a/tests/unittests/test_graph.cpp
+++ b/tests/unittests/test_graph.cpp
@@ -791,18 +791,10 @@ TEST(Graph, move_node_to_other_graph)
     EXPECT_TRUE(graph2.findNodeByUuid(A_uuid));
 }
 
-#include <gt_eventloop.h>
-
 TEST(Graph, move_nodes_to_other_graph)
 {
     Graph graph1;
     Graph graph2;
-
-    GraphExecutionModel model1(graph1);
-    GraphExecutionModel model2(graph2);
-
-    ASSERT_TRUE(model1.autoEvaluateGraph());
-    ASSERT_TRUE(model2.autoEvaluateGraph());
 
     ASSERT_TRUE(test::buildLinearGraph(graph1));
 
@@ -829,13 +821,6 @@ TEST(Graph, move_nodes_to_other_graph)
     EXPECT_EQ(graph1.globalConnectionModel().size(), globalConnections);
     EXPECT_NE(graph2.globalConnectionModel().size(), globalConnections);
 
-    GtEventLoop loop(std::chrono::seconds(1));
-    loop.exec();
-    ASSERT_TRUE(model1.isGraphEvaluated());
-    ASSERT_TRUE(model2.isGraphEvaluated());
-    ASSERT_FALSE(model1.isEvaluating());
-    ASSERT_FALSE(model2.isEvaluating());
-
     // move node
     QVector<NodeId> nodeIds = {A_id, B_id, C_id, D_id};
     EXPECT_TRUE(graph1.moveNodesAndConnections(nodeIds, graph2));
@@ -854,23 +839,12 @@ TEST(Graph, move_nodes_to_other_graph)
     EXPECT_TRUE(graph2.globalConnectionModel() == globalModel);
     EXPECT_NE(graph1.globalConnectionModel().size(), globalConnections);
     EXPECT_EQ(graph2.globalConnectionModel().size(), globalConnections);
-
-    loop.exec();
-    ASSERT_TRUE(model1.isGraphEvaluated());
-    ASSERT_TRUE(model2.isGraphEvaluated());
-    ASSERT_FALSE(model1.isEvaluating());
-    ASSERT_FALSE(model2.isEvaluating());
 }
 
 TEST(Graph, move_graph_to_other_graph)
 {
     Graph graph1;
     Graph graph2;
-
-    GraphExecutionModel model1(graph1);
-    GraphExecutionModel model2(graph2);
-    ASSERT_TRUE(model1.autoEvaluateGraph());
-    ASSERT_TRUE(model2.autoEvaluateGraph());
 
     ASSERT_TRUE(test::buildGraphWithGroup(graph1));
 
@@ -904,13 +878,6 @@ TEST(Graph, move_graph_to_other_graph)
     EXPECT_EQ(graph1.globalConnectionModel().size(), globalConnections);
     EXPECT_NE(graph2.globalConnectionModel().size(), globalConnections);
 
-    GtEventLoop loop(std::chrono::seconds(1));
-    loop.exec();
-    ASSERT_TRUE(model1.isGraphEvaluated());
-    ASSERT_TRUE(model2.isGraphEvaluated());
-    ASSERT_FALSE(model1.isEvaluating());
-    ASSERT_FALSE(model2.isEvaluating());
-
     // move node
     QVector<NodeId> nodeIds = {A_id, B_id, C_id, D_id, E_id};
     EXPECT_TRUE(graph1.moveNodesAndConnections(nodeIds, graph2));
@@ -936,10 +903,4 @@ TEST(Graph, move_graph_to_other_graph)
     EXPECT_TRUE(graph2.globalConnectionModel() == globalModel);
     EXPECT_NE(graph1.globalConnectionModel().size(), globalConnections);
     EXPECT_EQ(graph2.globalConnectionModel().size(), globalConnections);
-
-    loop.exec();
-    ASSERT_TRUE(model1.isGraphEvaluated());
-    ASSERT_TRUE(model2.isGraphEvaluated());
-    ASSERT_FALSE(model1.isEvaluating());
-    ASSERT_FALSE(model2.isEvaluating());
 }


### PR DESCRIPTION
Closes #244 

- fixed the bugged behavior by resetting both connection models. This was by far the simplest approach and seemed to work all times.

Addtionally:
- performed light refactoring
- updated logging statements to clearly state component that message belongs to