### PR TITLE
Resolve: "Use Pimpl to reduce future API/ABI-incompatibilities"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-*This release is not ABI compatible with `0.12.0`*
+## [0.13.0] - 2025-02-21
+*This release is not ABI compatible with `0.12.0` and may break API*
 
 ### Added
-- Subgraphes can now also be expand, effectively ungrouping the subgraph. - #64
+- Subgraphs can now also be expanded, thus allowing to "ungroug" subgraphs previously created. - #64
 - Allowed nodes to be marked as deprecated. Deprecated nodes should be replaced as soon as possible as a future release may remove the node entirely. - #225
+- Nodes can now have a "display icon" that is drawn in the node header. - #236
 
 ### Changed
-- Major refactoring of the graph execution model. Now only one exec model is used to manage and evaluate a graph hierarchy, improving the handling of nested graphs and fixing unhandled edge cases. Additionally the future-object returned by the exec model is now far more flexible and user friendly, allowing above else the registration of callback functions. - #112
-- IntelliGraph specific compile flags were renamed; node's size and position properties are now always hidden unless the associated compiler flag was set. - #205
+- Major refactoring of the graph execution model. A single execution model is used to manage and evaluate the entire graph hierarchy, improving the handling of nested graphs and fixing previously unhandled edge cases. Additionally a helper object returned by the execution model when executin nodes/graphs is now more capable, allowing the registration of async callback functions. - #112
+- IntelliGraph specific compile flags were renamed; node's size and position properties are now always hidden unless the associated compiler flag is set. - #205
+- Most inputs nodes have been refactored and streamlined. Duplicate nodes have been removed. - #224
 
 ### Fixed
-- Fixed error when creating and loading a project with an empty IntelliGraph package in GTlab 2.1.0 - #193
-- Fixed potential crashes when deletiing instances of `ObjectData` that were created in a separate thread. - #112
+- Fixed an error when creating and loading a project with an empty IntelliGraph package in GTlab 2.1.0 - #193
+- Fixed potential crashes when deleting instances of `ObjectData` that were created in a separate thread. - #112
 - Fixed port captions spanning multiple words being truncated. - #212
-- The graph view should now remeber more consistently whether a graph should be auto-evaluated. - #112
+- The graph view should now remember more consistently whether a graph should be auto-evaluated. - #112
 - If a node fails to evaluate all successor nodes are invalidated and marked as failed as well. - #221
 - Fixed menus of embedded widgets not beeing displayed outside of the node's bounding rect.
 

--- a/src/intelli/dynamicnode.h
+++ b/src/intelli/dynamicnode.h
@@ -30,6 +30,8 @@ class GT_INTELLI_EXPORT DynamicNode : public Node
 
 public:
 
+    ~DynamicNode();
+
     /// Option for the node creation
     enum Option
     {
@@ -204,13 +206,8 @@ private:
     using Node::insertOutPort;
     using Node::insertPort;
 
-    /// property container for the in ports
-    GtPropertyStructContainer m_inPorts;
-    /// property container for the out ports
-    GtPropertyStructContainer m_outPorts;
-
-    /// Node option
-    Option m_option = DynamicInputAndOutput;
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
 
     /**
      * @brief Returns the offset for to the first index of a dynamic port.

--- a/src/intelli/graph.cpp
+++ b/src/intelli/graph.cpp
@@ -689,7 +689,7 @@ Graph::appendGlobalConnection(Connection* guard, ConnectionId conId, Node& targe
         conUuid.inNodeId = inputProvider->uuid();
         conUuid.inPort   = GroupInputProvider::virtualPortId(conId.inPort);
 
-        appendGlobalConnection(nullptr, conUuid);
+        appendGlobalConnection(guard, conUuid);
     }
 
     // forwards outputs of subgraph to graph node

--- a/src/intelli/graph.h
+++ b/src/intelli/graph.h
@@ -528,24 +528,16 @@ public:
     }
 
     /**
-     * @brief Access the directed acyclic graph model used to manage the nodes
-     * and their connections
-     * @return DAG
-     */
-    [[deprecated("use `localConnectionModel` instead")]]
-    ConnectionModel const& dag() const { return m_local; }
-
-    /**
      * @brief Returns the local connection model.
      * @return Local connection model
      */
-    inline ConnectionModel const& connectionModel() const { return m_local; }
+    ConnectionModel const& connectionModel() const;
 
     /**
      * @brief Returns the global connection model.
      * @return Global connection model
      */
-    inline GlobalConnectionModel const& globalConnectionModel() const { return *m_global; }
+    GlobalConnectionModel const& globalConnectionModel() const;
 
     /**
      * @brief initializes the input and output of this graph
@@ -684,16 +676,7 @@ protected:
 private:
 
     struct Impl;
-
-    /// local connection graph
-    ConnectionModel m_local;
-    /// shred global connection graph
-    std::shared_ptr<GlobalConnectionModel> m_global = nullptr;
-    /// indicator if the connection model is currently beeing modified
-    int m_modificationCount = 0;
-    /// flag indicating that the connection model should be reset once
-    /// the graph is no longer being modified
-    bool m_resetAfterModification = false;
+    std::unique_ptr<Impl> pimpl;
 
     /**
      * @brief Whether this model is currently undergoing modification.

--- a/src/intelli/graphbuilder.h
+++ b/src/intelli/graphbuilder.h
@@ -45,7 +45,7 @@ public:
     GraphBuilder(GraphBuilder&&) = default;
     GraphBuilder& operator=(GraphBuilder const&) = delete;
     GraphBuilder& operator=(GraphBuilder&&) = default;
-    ~GraphBuilder() = default;
+    ~GraphBuilder();
 
     /**
      * Helper struct for accessing graph data
@@ -142,7 +142,8 @@ public:
 
 private:
 
-    Graph* m_graph;
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
 
     Node& addNodeHelper(std::unique_ptr<Node> node, Position pos = {}, NodeUuid const& nodeUuid = {});
 };

--- a/src/intelli/graphdatamodel.h
+++ b/src/intelli/graphdatamodel.h
@@ -40,7 +40,7 @@ struct DataItem
     /// internal evalution state
     NodeEvalState state = NodeEvalState::Outdated;
     /// counter of nodes that are running in subgraph nodes
-    size_t m_evaluatingChildNodes = 0;
+    size_t evaluatingChildNodes = 0;
 
     /**
      * @brief Returns the ancestors or descendants depending on the port type

--- a/src/intelli/graphexecmodel.h
+++ b/src/intelli/graphexecmodel.h
@@ -274,7 +274,7 @@ public:
      * @return Execution data
      */
     GT_NO_DISCARD
-    inline auto const& data() const { return m_data; }
+    inline GraphDataModel const& data() const;
 
 protected:
 
@@ -340,29 +340,7 @@ private:
 
     // helper struct to "hide" implementation details
     struct Impl;
-
-    /// assoicated graph
-    QPointer<Graph> m_graph;
-    /// data model for all nodes and their ports
-    GraphDataModel m_data;
-    /// nodes that should be evaluated
-    std::vector<NodeUuid> m_targetNodes;
-    /// nodes that should be queued and executed at some point to evaluate
-    /// all target nodes
-    std::vector<NodeUuid> m_pendingNodes;
-    /// nodes that should be considered for auto evaluation
-    std::set<NodeUuid> m_autoEvaluatingNodes;
-    /// nodes that are ready and waiting for evaluation
-    std::vector<NodeUuid> m_queuedNodes;
-    /// nodes that are currently evaluating
-    std::vector<NodeUuid> m_evaluatingNodes;
-    /// graphs that should be auto evaluated
-    std::vector<NodeUuid> m_autoEvaluatingGraphs;
-    /// indicator if the exec model is currently beeing modified and thus
-    /// should halt execution
-    int m_modificationCount = 0;
-    /// indicator if queue is currently being evaluated
-    bool m_isEvaluatingQueue = false;
+    std::unique_ptr<Impl> pimpl;
 
     void beginReset();
 

--- a/src/intelli/gui/graphics/nodeobject.h
+++ b/src/intelli/gui/graphics/nodeobject.h
@@ -39,6 +39,8 @@ class GT_INTELLI_EXPORT NodeGraphicsObject : public QGraphicsObject
 {
     Q_OBJECT
 
+    class NodeProxyWidget;
+
 public:
 
     class Highlights;
@@ -259,38 +261,7 @@ signals:
 private:
 
     struct Impl;
-    class NodeProxyWidget;
-
-    enum State
-    {
-        Normal = 0,
-        Translating,
-        Resizing
-    };
-
-    /// Pointer to graph scene data
-    GraphSceneData* m_sceneData;
-    /// Associated node
-    QPointer<Node> m_node;
-    /// ui data
-    std::unique_ptr<NodeUIData> m_uiData;
-    /// Geometry
-    std::unique_ptr<NodeGeometry> m_geometry;
-    /// Painter
-    std::unique_ptr<NodePainter> m_painter;
-    /// Central widget
-    QPointer<QGraphicsProxyWidget> m_proxyWidget;
-    /// Node eval state object
-    NodeEvalStateGraphicsObject* m_evalStateObject = nullptr;
-    /// Holds how much the node was shifted since the beginning of a
-    /// translation operation
-    QPointF m_translationDiff;
-    /// Highlight data
-    Highlights m_highlights;
-    /// State flag
-    State m_state = Normal;
-    /// Whether node is hovered
-    bool m_hovered = false;
+    std::unique_ptr<Impl> pimpl;
 
     /**
      * @brief selects the item and the node in the application

--- a/src/intelli/gui/nodegeometry.cpp
+++ b/src/intelli/gui/nodegeometry.cpp
@@ -218,9 +218,8 @@ NodeGeometry::captionRect() const
 QSize
 NodeGeometry::captionSize() const
 {
-    QFont f;
-    f.setBold(true);
-    QFontMetrics metrics{f};
+    auto& style = style::currentStyle().node;
+    QFontMetrics metrics{style.headerFont};
 
     constexpr int errorMargin = 2; // margin to avoid truncation of caption
 
@@ -311,7 +310,7 @@ NodeGeometry::portRect(PortType type, PortIndex idx) const
     auto& node = this->node();
     auto& style = style::currentStyle().node;
 
-    QFontMetrics metrcis(QFont{});
+    QFontMetrics metrcis(style.bodyFont);
 
     // height
     auto body = nodeBodyRect();
@@ -348,14 +347,15 @@ NodeGeometry::portCaptionRect(PortType type, PortIndex idx) const
     assert(type != PortType::NoType);
     if (node().ports(type).size() < idx) return {};
 
-    auto& node = this->node();
-    auto* port = node.port(node.portId(type, idx));
+    auto& style = style::currentStyle().node;
+    auto& node  = this->node();
+    auto* port  = node.port(node.portId(type, idx));
     assert(port);
 
     if (!port->visible) return {};
 
     // height
-    QFontMetrics metrics{QFont()};
+    QFontMetrics metrics{style.bodyFont};
     int height = metrics.height();
 
     // width

--- a/src/intelli/gui/nodegeometry.h
+++ b/src/intelli/gui/nodegeometry.h
@@ -299,7 +299,7 @@ private:
     /// cache for shape
     mutable tl::optional<QPainterPath> m_shape;
     /// padding
-    uint8_t __padding[216];
+    alignas(8) uint8_t __padding[24];
 
     /**
      * @brief Returns whether to position the node below all ports

--- a/src/intelli/gui/nodepainter.cpp
+++ b/src/intelli/gui/nodepainter.cpp
@@ -229,6 +229,8 @@ NodePainter::drawPortCaption(QPainter& painter,
 {
     auto& factory = NodeDataFactory::instance();
 
+    painter.setFont(style::currentStyle().node.bodyFont);
+
     painter.setBrush(Qt::NoBrush);
     painter.setPen((flags & PortConnected) ?
                        gt::gui::color::text() :
@@ -280,19 +282,12 @@ NodePainter::drawCaption(QPainter& painter) const
 
     if (node.nodeFlags() & NodeFlag::HideCaption) return;
 
-    QFont f = painter.font();
-    bool isBold = f.bold();
-    f.setBold(true);
-
     QRectF rect = geometry().captionRect();
 
-    painter.setFont(f);
+    painter.setFont(style::currentStyle().node.headerFont);
     painter.setBrush(Qt::NoBrush);
     painter.setPen(gt::gui::color::text());
     painter.drawText(rect, node.caption(), QTextOption{Qt::AlignHCenter});
-
-    f.setBold(isBold);
-    painter.setFont(f);
 
 #ifdef GT_INTELLI_DEBUG_NODE_GRAPHICS
     painter.setBrush(Qt::NoBrush);

--- a/src/intelli/gui/nodepainter.h
+++ b/src/intelli/gui/nodepainter.h
@@ -196,7 +196,7 @@ private:
     /// Geometry
     NodeGeometry const* m_geometry;
     /// padding
-    uint8_t __padding[16];
+    alignas(8) uint8_t __padding[16];
 };
 
 } // namespace intelli

--- a/src/intelli/gui/nodepainter.h
+++ b/src/intelli/gui/nodepainter.h
@@ -139,7 +139,7 @@ public:
      * @brief Draws the resize handle
      * @param painter Painter to draw with
      */
-    void drawResizeHandle(QPainter& painter) const;
+    virtual void drawResizeHandle(QPainter& painter) const;
 
     void drawIcon(QPainter& painter) const;
 

--- a/src/intelli/gui/nodeui.cpp
+++ b/src/intelli/gui/nodeui.cpp
@@ -53,7 +53,14 @@ inline BoolObjectMethod operator+(BoolObjectMethod fA, Functor fOther)
 
 using namespace intelli;
 
-NodeUI::NodeUI(Option option)
+struct NodeUI::Impl
+{
+    /// List of custom port actions
+    QList<PortUIAction> portActions;
+};
+
+NodeUI::NodeUI(Option option) :
+    pimpl(std::make_unique<Impl>())
 {
     setObjectName(QStringLiteral("IntelliGraphNodeUI"));
 
@@ -153,6 +160,8 @@ NodeUI::NodeUI(Option option)
       .setVisibilityMethod(toGraph);
 }
 
+NodeUI::~NodeUI() = default;
+
 std::unique_ptr<NodePainter>
 NodeUI::painter(NodeGraphicsObject const& object,
                 NodeGeometry const& geometry) const
@@ -225,8 +234,8 @@ PortUIAction&
 NodeUI::addPortAction(const QString& actionText,
                                     PortActionFunction actionMethod)
 {
-    m_portActions.append(PortUIAction(actionText, std::move(actionMethod)));
-    return m_portActions.back();
+    pimpl->portActions.append(PortUIAction(actionText, std::move(actionMethod)));
+    return pimpl->portActions.back();
 }
 
 Node*
@@ -407,3 +416,9 @@ NodeUI::validatorRegExp(GtObject* obj)
     return retVal;
 }
 #endif
+
+QList<PortUIAction> const&
+intelli::NodeUI::portActions() const
+{
+    return pimpl->portActions;
+}

--- a/src/intelli/gui/nodeui.h
+++ b/src/intelli/gui/nodeui.h
@@ -48,6 +48,11 @@ public:
     using PortActionFunction = typename PortUIAction::ActionMethod;
 
     Q_INVOKABLE NodeUI(Option option = NoOption);
+    NodeUI(NodeUI const&) = delete;
+    NodeUI(NodeUI&&) = delete;
+    NodeUI& operator=(NodeUI const&) = delete;
+    NodeUI& operator=(NodeUI&&) = delete;
+    ~NodeUI() override;
     
     /**
      * @brief Returns a painter object, used to paint the graphics object
@@ -166,7 +171,7 @@ public:
      * @brief Returns the list of all port actions registered
      * @return
      */
-    QList<PortUIAction> const& portActions() const { return m_portActions; }
+    QList<PortUIAction> const& portActions() const;
 
 #if GT_VERSION >= 0x020100
     /**
@@ -199,8 +204,8 @@ protected:
 
 private:
 
-    /// List of custom port actions
-    QList<PortUIAction> m_portActions;
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
 
     /**
      * @brief Clears the intelli graph (i.e. removes all nodes and connections)

--- a/src/intelli/gui/style.cpp
+++ b/src/intelli/gui/style.cpp
@@ -61,6 +61,9 @@ static auto& styles()
         style.node.background = QColor{36, 49, 63};
         style.node.defaultOutline = QColor{63, 73, 86};
         style.node.selectedOutline = QColor{255, 165, 0};
+
+        style.node.headerFont.setBold(true);
+
         style.node.hoveredOutline = style.node.defaultOutline;
         style.node.compatiblityTintModifier = 20;
 

--- a/src/intelli/gui/style.h
+++ b/src/intelli/gui/style.h
@@ -14,6 +14,7 @@
 #include <intelli/globals.h>
 
 #include <QColor>
+#include <QFont>
 
 namespace intelli
 {
@@ -93,6 +94,9 @@ struct StyleData
         QColor background;
         /// color of the grid
         QColor gridline;
+
+    private:
+        alignas(8) uint8_t __padding[32];
     } view;
 
     /// style data for nodes
@@ -102,6 +106,8 @@ struct StyleData
         QColor background;
         /// outline colors
         QColor defaultOutline, selectedOutline, hoveredOutline;
+        /// fonts
+        QFont headerFont{}, bodyFont{};
         /// outline width
         double defaultOutlineWidth = 1.0;
         double hoveredOutlineWidth = 1.5;
@@ -117,6 +123,9 @@ struct StyleData
         /// modifier to apply to all r-g-b components when highlighting
         /// compatible nodes (while creatimg a draft connection)
         int compatiblityTintModifier = 20;
+
+    private:
+        alignas(8) uint8_t __padding[16];
     } node;
 
     /// style data for connections
@@ -141,7 +150,13 @@ struct StyleData
          * @return Color of the type id
          */
         GT_INTELLI_EXPORT QColor typeColor(TypeId const& typeId) const;
-    } connection;
+
+    private:
+        alignas(8) uint8_t __padding[16];
+    } connection ;
+
+private:
+    uint8_t __padding[32];
 };
 
 /**

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -84,7 +84,7 @@ static const int ns_meta_port_type = [](){
 GtVersionNumber
 GtIntelliGraphModule::version()
 {
-    return GtVersionNumber(0, 13, 0, "dev1");
+    return GtVersionNumber(0, 13, 0);
 }
 
 QString
@@ -156,7 +156,7 @@ GtIntelliGraphModule::upgradeRoutines() const
     routines << to_0_12_0;
 
     gt::VersionUpgradeRoutine to_0_13_0;
-    to_0_13_0.target = GtVersionNumber{0, 13, 0, "dev1"};
+    to_0_13_0.target = GtVersionNumber{0, 13, 0};
     to_0_13_0.f = upgrade_to_0_13_0;
     routines << to_0_13_0;
 

--- a/src/intelli/nodedatafactory.h
+++ b/src/intelli/nodedatafactory.h
@@ -56,6 +56,8 @@ class GT_INTELLI_EXPORT NodeDataFactory : public GtAbstractObjectFactory
 
 public:
 
+    ~NodeDataFactory();
+
     /**
      * @brief instance
      * @return
@@ -147,14 +149,12 @@ public:
 
 private:
 
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
+
     // hide some functions
     using GtAbstractObjectFactory::newObject;
     using GtAbstractObjectFactory::registerClass;
-
-    /// registered type names (used as default port captions)
-    QHash<TypeId, TypeName> m_typeNames;
-    /// registered conversion functions
-    QMultiHash<TypeId, Conversion> m_conversions;
 
     /// private constructor
     NodeDataFactory();

--- a/src/intelli/nodefactory.h
+++ b/src/intelli/nodefactory.h
@@ -30,13 +30,15 @@ class GT_INTELLI_EXPORT NodeFactory : public GtAbstractObjectFactory
 
 public:
 
+    ~NodeFactory();
+
     /**
      * @brief instance
      * @return
      */
     static NodeFactory& instance();
 
-    QStringList registeredNodes() const { return knownClasses(); };
+    QStringList registeredNodes() const;
 
     QStringList registeredCategories() const;
 
@@ -69,21 +71,12 @@ public:
 
 private:
 
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
+
     // hide some functions
     using GtAbstractObjectFactory::newObject;
     using GtAbstractObjectFactory::registerClass;
-
-    using ClassName = QString;
-    using NodeCategory = QString;
-    using NodeName = QString;
-
-    struct NodeMetaData
-    {
-        NodeCategory category;
-        NodeName modelName;
-    };
-
-    QHash<ClassName, NodeMetaData> m_data;
 
     NodeFactory();
 };


### PR DESCRIPTION
Interfaces that were pimpled:

- [x] Node (already pimpled)
- [x] NodeGraphicsObject
- [x] DynamicNode
- [x] Graph
- [x] GraphExecutionModel
- [x] GraphBuilder
- [x] NodeDataFactory
- [x] NodeFactory
- [x] NodeUI

Added padding other measures to reduce chance of ABI changes:
- [x] NodePainter
- [x] NodeGeometry

Closes #232 