### PR TITLE
Fixed multiple memory leaks

### DIFF
--- a/src/intelli/gui/widgets/doubleinputwidget.cpp
+++ b/src/intelli/gui/widgets/doubleinputwidget.cpp
@@ -30,7 +30,7 @@ DoubleInputWidget::DoubleInputWidget(InputMode mode,
                               new EditableIntegerLabel("", nullptr),
                               parent)
 {
-    valueEdit()->setValidator(new QRegExpValidator(gt::re::forDoubles()));
+    valueEdit()->setValidator(new QRegExpValidator(gt::re::forDoubles(), this));
 
     // emulate double slider
     slider()->setMinimum(0);

--- a/src/intelli/gui/widgets/editablelabel.cpp
+++ b/src/intelli/gui/widgets/editablelabel.cpp
@@ -132,11 +132,11 @@ EditableLabel::onTextEdited()
 EditableIntegerLabel::EditableIntegerLabel(QString const& text, QWidget* parent) :
     EditableNumberLabel<int>(text, parent)
 {
-    edit()->setValidator(new QRegExpValidator(QRegExp("-?[0-9]+")));
+    edit()->setValidator(new QRegExpValidator(QRegExp("-?[0-9]+"), this));
 }
 
 EditableDoubleLabel::EditableDoubleLabel(QString const& text, QWidget* parent) :
     EditableNumberLabel<double>(text, parent)
 {
-    edit()->setValidator(new QRegExpValidator(gt::re::forDoubles()));
+    edit()->setValidator(new QRegExpValidator(gt::re::forDoubles(), this));
 }

--- a/src/intelli/gui/widgets/intinputwidget.cpp
+++ b/src/intelli/gui/widgets/intinputwidget.cpp
@@ -29,7 +29,7 @@ IntInputWidget::IntInputWidget(InputMode mode,
                               new EditableIntegerLabel("", nullptr),
                               parent)
 {
-    valueEdit()->setValidator(new QRegExpValidator(QRegExp("-?[0-9]+")));
+    valueEdit()->setValidator(new QRegExpValidator(QRegExp("-?[0-9]+"), this));
 }
 
 int


### PR DESCRIPTION
As the line edit does not take ownership of its validator, we need to add a parent object to the newly created validators.

Found with AddressSanitizer.