### PR TITLE
Fix inconsistencies when deleting connections to input providers

### DIFF
--- a/src/intelli/graph.cpp
+++ b/src/intelli/graph.cpp
@@ -46,12 +46,12 @@ Graph::~Graph()
     Modification cmd = modify();
     Q_UNUSED(cmd);
 
-    auto const& nodes = this->nodes();
-    qDeleteAll(nodes);
-
     // remove connections
     auto& conGroup = this->connectionGroup();
     delete& conGroup;
+
+    auto const& nodes = this->nodes();
+    qDeleteAll(nodes);
 }
 
 Graph*


### PR DESCRIPTION
reordered deletion of nodes and connections when deleting a graph to avoid inconsistencies in global connection model