### PR TITLE
Resolve: "Calculator Executor Node does update correctly when disconnecting ports"

### DIFF
--- a/src/intelli/node/genericcalculatorexec.cpp
+++ b/src/intelli/node/genericcalculatorexec.cpp
@@ -17,6 +17,7 @@
 
 #include "gt_algorithms.h"
 #include "gt_coreapplication.h"
+#include "gt_project.h"
 #include "gt_calculator.h"
 #include "gt_calculatorfactory.h"
 

--- a/src/intelli/node/genericcalculatorexec.cpp
+++ b/src/intelli/node/genericcalculatorexec.cpp
@@ -324,6 +324,7 @@ GenericCalculatorExecNode::GenericCalculatorExecNode() :
         lay->addWidget(edit);
 
         auto* view = new GtPropertyTreeView(gtApp->currentProject());
+        view->setAnimated(false);
         lay->addWidget(view);
 
         auto updateView = [view, this](){

--- a/src/intelli/node/genericcalculatorexec.cpp
+++ b/src/intelli/node/genericcalculatorexec.cpp
@@ -333,6 +333,9 @@ GenericCalculatorExecNode::GenericCalculatorExecNode() :
             if (obj)
             {
                 view->setObject(obj);
+                // collapse first category
+                view->collapse(view->model()->index(0, 0, view->rootIndex()));
+
                 connect(obj, qOverload<GtObject*, GtAbstractProperty*>(&GtObject::dataChanged),
                         this, &GenericCalculatorExecNode::onCurrentObjectDataChanged,
                         Qt::UniqueConnection);
@@ -493,6 +496,8 @@ GenericCalculatorExecNode::initPorts() // generate default parameter set
         if (prop->category() == GtAbstractProperty::Custom &&
             prop->categoryToString() == defaultCategory)
         {
+            // hide some default entries
+            if (prop->ident() == QStringLiteral("skip")) prop->hide(true);
             continue;
         }
 

--- a/src/intelli/node/genericcalculatorexec.cpp
+++ b/src/intelli/node/genericcalculatorexec.cpp
@@ -17,7 +17,6 @@
 
 #include "gt_algorithms.h"
 #include "gt_coreapplication.h"
-#include "gt_project.h"
 #include "gt_calculator.h"
 #include "gt_calculatorfactory.h"
 

--- a/src/intelli/node/genericcalculatorexec.cpp
+++ b/src/intelli/node/genericcalculatorexec.cpp
@@ -84,7 +84,7 @@ struct GenericCalculatorExecNode::Impl
         {
             if (auto* prop = obj->findProperty(ports[portId]))
             {
-                prop->hide(true);
+                prop->hide(hide);
                 emit node.currentObjectChanged();
                 return true;
             }
@@ -637,7 +637,7 @@ GenericCalculatorExecNode::onPortDisconnected(PortId portId)
     bool success = Impl::setPortPropertyHidden(*this, m_calcInPorts, portId, false);
     if (!success)
     {
-        Impl::setPortPropertyHidden(*this, m_calcOutPorts, portId, true);
+        Impl::setPortPropertyHidden(*this, m_calcOutPorts, portId, false);
     }
 }
 


### PR DESCRIPTION
- fix calculator executor node not updating correctly when disconnecting ports
- collapse default category
- hide 'skip' entry in default category

Closes #262