### PR TITLE
Object Sink Node implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,7 @@ set(PUBLIC_HEADERS
     intelli/node/input/intinput.h
     intelli/node/input/objectinput.h
     intelli/node/input/stringinput.h
+    intelli/node/objectsink.h
     intelli/property/color.h
     intelli/property/metaenum.h
     intelli/property/stringselection.h
@@ -189,7 +190,8 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/node/input/intinput.cpp
     intelli/node/input/objectinput.cpp
     intelli/node/input/stringinput.cpp
-    intelli/node/stringselection.h
+    intelli/node/stringselection.cpp
+    intelli/node/objectsink.cpp
     intelli/gui/nodegeometry.cpp
     intelli/gui/nodepainter.cpp
     intelli/gui/nodeui.cpp
@@ -228,7 +230,6 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
 target_sources(GTlabIntelliGraph
   PRIVATE
     intelli/gui/nodeuidata.h intelli/gui/nodeuidata.cpp
-     intelli/node/stringselection.cpp
 )
 
 target_link_libraries(GTlabIntelliGraph

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/nodegeometry.cpp
     intelli/gui/nodepainter.cpp
     intelli/gui/nodeui.cpp
+    intelli/gui/nodeuidata.cpp
     intelli/gui/grapheditor.cpp
     intelli/gui/graphscene.cpp
     intelli/gui/graphscenemanager.cpp
@@ -225,11 +226,6 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/property/uint.cpp
 
     intelli/node/binarydisplay.h intelli/node/binarydisplay.cpp
-)
-
-target_sources(GTlabIntelliGraph
-  PRIVATE
-    intelli/gui/nodeuidata.h intelli/gui/nodeuidata.cpp
 )
 
 target_link_libraries(GTlabIntelliGraph

--- a/src/intelli/core.cpp
+++ b/src/intelli/core.cpp
@@ -53,6 +53,8 @@
 
 #include "intelli/node/projectinfo.h"
 
+#include "intelli/node/objectsink.h"
+
 #include "intelli/nodedatafactory.h"
 #include "intelli/nodefactory.h"
 
@@ -135,6 +137,7 @@ intelli::registerDefaultNodes()
 
         GT_INTELLI_REGISTER_NODE(ObjectMementoNode, catObject);
         GT_INTELLI_REGISTER_NODE(FindDirectChildNode, catObject);
+        GT_INTELLI_REGISTER_NODE(ObjectSink, catObject);
 
         GT_INTELLI_REGISTER_NODE(FileInputNode, catInput);
         GT_INTELLI_REGISTER_NODE(FileReaderNode, catFile);

--- a/src/intelli/node/objectsink.cpp
+++ b/src/intelli/node/objectsink.cpp
@@ -143,7 +143,9 @@ ObjectSink::doExport()
         GtObject* sourceClone = source->clone();
         GtObject* targetParent = target->parentObject();
         QString oldUUID = target->uuid();
+        QString oldName = target->objectName();
         sourceClone->setUuid(oldUUID);
+        sourceClone->setObjectName(oldName);
         target->deleteLater();
         sourceClone->moveToThread(targetParent->thread());
 

--- a/src/intelli/node/objectsink.cpp
+++ b/src/intelli/node/objectsink.cpp
@@ -21,10 +21,9 @@ using namespace intelli;
 ObjectSink::ObjectSink() :
     Node("Object sink"),
     m_target("target", tr("Target"), tr("Target"), QString(), this,
-               QStringList() << GT_CLASSNAME(GtObject), true)
+               QStringList() << GT_CLASSNAME(GtObject), true),
+    m_in(addInPort({typeId<ObjectData>(), tr("Object")}))
 {
-    m_in  = addInPort({typeId<ObjectData>(), tr("Object")});
-
     registerProperty(m_target);
 
     setNodeEvalMode(NodeEvalMode::Blocking);

--- a/src/intelli/node/objectsink.cpp
+++ b/src/intelli/node/objectsink.cpp
@@ -10,21 +10,127 @@
 
 #include <intelli/data/object.h>
 
+#include <QPushButton>
+
+#include "gt_application.h"
+#include "gt_datamodel.h"
+#include "gt_project.h"
+
 using namespace intelli;
 
 ObjectSink::ObjectSink() :
-    Node("Object sink")
+    Node("Object sink"),
+    m_target("target", tr("Target"), tr("Target"), QString(), this,
+               QStringList() << GT_CLASSNAME(GtObject), true)
 {
     m_in  = addInPort({typeId<ObjectData>(), tr("Object")});
+
+    registerProperty(m_target);
+
+    // registering the widget factory
+    registerWidgetFactory([=](intelli::Node& /*this*/){
+        auto w = std::make_unique<QPushButton>("Export");
+
+        connect(w.get(), &QPushButton::clicked, this,
+                [=, w_ = w.get()](){
+                    doExport();
+                });
+
+        connect(this, &ObjectSink::exportActivated, w.get(),
+                [=, w_ = w.get()](bool a) {
+                    w_->setEnabled(a);
+
+                    if (a)
+                    {
+                        setButtonColor(w_, QColor(252, 186, 3));
+                    }
+                    else
+                    {
+                        w_->setStyleSheet({});
+                    }
+                });
+
+        connect(this, &ObjectSink::exportFinished, w.get(),
+                [=, w_ = w.get()](bool a) {
+                    if (a)
+                    {
+                        setButtonColor(w_, QColor(0, 100, 10));
+                    }
+                    else
+                    {
+                        setButtonColor(w_, QColor(150, 40, 0));
+                    }
+                });
+
+        return w;
+    });
 }
 
 void
 intelli::ObjectSink::eval()
 {
+    auto data_tmp = nodeData<ObjectData>(m_in);
+
+    if (data_tmp)
+    {
+        emit exportActivated(true);
+    }
+    else
+    {
+        emit exportActivated(false);
+    }
+}
+
+void
+ObjectSink::setButtonColor(QPushButton* button, const QColor& col)
+{
+    if (!button) return;
+
+    static const QString styleBase = QStringLiteral(R"(
+      QAbstractButton{
+        margin: 2px;
+        max-width: 40px; min-height: 20px;
+        border: 1px solid #777777; border-radius: 2px;
+        background: qlineargradient( x1:0 y1:0, x2:0 y2:1, stop:0 %3, stop:1 '%1');
+      }
+      QAbstractButton:hover{ background-color: %2}
+      QAbstractButton:pressed{ background-color: %2;})");
+
+
+    QColor highlightColor = col.lighter();
+    QColor gradientUpColor = col.lighter(110);
+    QColor gradientLoColor = col.darker(110);
+
+    QString style = QString(styleBase).arg(QVariant(gradientLoColor).toString(),
+
+                                           QVariant(highlightColor).toString(),
+                                           QVariant(gradientUpColor).toString());
+
+    button->setStyleSheet(style);
+    button->update();
+}
+
+void
+ObjectSink::doExport()
+{
     auto data = nodeData<ObjectData>(m_in);
 
-    if (!data || !data->object())
-    {
-        return;
-    }
+    const GtObject* source = data->object();
+
+    QString targetUUID = m_target.getVal();
+
+    if (targetUUID.isEmpty()) return;
+
+    GtProject* currProj = gtApp->currentProject();
+
+    if (!currProj) return;
+
+    GtObject* target = m_target.linkedObject(currProj);
+
+    if (!target) return;
+
+    GtObject* sourceClone = source->clone();
+    sourceClone->moveToThread(target->thread());
+
+    gtDataModel->appendChild(sourceClone, target);
 }

--- a/src/intelli/node/objectsink.cpp
+++ b/src/intelli/node/objectsink.cpp
@@ -58,6 +58,8 @@ ObjectSink::doExport()
 {
     auto data = nodeData<ObjectData>(m_in);
 
+    if (!data) return;
+
     const GtObject* source = data->object();
 
     QString targetUUID = m_target.getVal();

--- a/src/intelli/node/objectsink.cpp
+++ b/src/intelli/node/objectsink.cpp
@@ -1,0 +1,30 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Jens Schmeink <jens.schmeink@dlr.de>
+ */
+#include "objectsink.h"
+
+#include <intelli/data/object.h>
+
+using namespace intelli;
+
+ObjectSink::ObjectSink() :
+    Node("Object sink")
+{
+    m_in  = addInPort({typeId<ObjectData>(), tr("Object")});
+}
+
+void
+intelli::ObjectSink::eval()
+{
+    auto data = nodeData<ObjectData>(m_in);
+
+    if (!data || !data->object())
+    {
+        return;
+    }
+}

--- a/src/intelli/node/objectsink.h
+++ b/src/intelli/node/objectsink.h
@@ -1,0 +1,34 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Jens Schmeink <jens.schmeink@dlr.de>
+ */
+
+#ifndef GT_INTELLI_OBJECTSINK_H
+#define GT_INTELLI_OBJECTSINK_H
+
+#include "intelli/node.h"
+
+namespace intelli
+{
+
+class ObjectSink : public Node
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE ObjectSink();
+
+protected:
+    void eval() override;
+
+private:
+    PortId m_in;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_OBJECTSINK_H

--- a/src/intelli/node/objectsink.h
+++ b/src/intelli/node/objectsink.h
@@ -25,23 +25,13 @@ class ObjectSink : public Node
 public:
     Q_INVOKABLE ObjectSink();
 
-protected:
-    void eval() override;
-
 private:
     PortId m_in;
 
     GtObjectLinkProperty m_target;
 
-    void setButtonColor(QPushButton* button, const QColor& col);
-
 private slots:
     void doExport();
-
-signals:
-    void exportActivated(bool);
-
-    void exportFinished(bool);
 };
 
 } // namespace intelli

--- a/src/intelli/node/objectsink.h
+++ b/src/intelli/node/objectsink.h
@@ -10,7 +10,10 @@
 #ifndef GT_INTELLI_OBJECTSINK_H
 #define GT_INTELLI_OBJECTSINK_H
 
+#include "gt_objectlinkproperty.h"
 #include "intelli/node.h"
+
+class QPushButton;
 
 namespace intelli
 {
@@ -27,6 +30,18 @@ protected:
 
 private:
     PortId m_in;
+
+    GtObjectLinkProperty m_target;
+
+    void setButtonColor(QPushButton* button, const QColor& col);
+
+private slots:
+    void doExport();
+
+signals:
+    void exportActivated(bool);
+
+    void exportFinished(bool);
 };
 
 } // namespace intelli


### PR DESCRIPTION
This PR is relevant for HGF presentation. With the new implemented node it is possible to write an object from the graph to the project datamodel instance. If the object from the graph and the target are of the same class the object is overwritten, else it is appended.