### PR TITLE
Resolve: "Grouping nodes into subgraphs causes some connections to disappear"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moving a node now creates an undo command. - #41
 
 ### Fixed
-- The overlay buttons in a graph scene no longer create undo/redo commands. - #271
-- Nodes that have the `UserDeletable` flag set, can no longer be deleted. A popup is displayed to notify the user in such a case. Custom delete actions are used, identified via the shortcut of an UI action - #270
-- Connections to unknown nodes are now kept and not deleted upon loading a project with missing modules/unknown nodes. - #107
+- Fixed instantiation of outgoing connections when grouping nodes. - #277
 - Fixed slider input mode for number input nodes not committing value. - #272
+- The overlay buttons in a graph scene no longer create undo/redo commands. - #271
+- Nodes that have the `UserDeletable` flag set, can no longer be deleted. A popup is displayed to notify the user in such a case. Custom delete actions are used, if the shortcut of an UI action matches the delete shortcut. - #270
+- Connections to unknown nodes are no longer deleted upon loading a project with missing modules/unknown nodes. - #107
 
 ## [0.13.0] - 2025-03-19
 *This release is not ABI compatible with `0.12.0` and may break API*

--- a/src/intelli/graph.h
+++ b/src/intelli/graph.h
@@ -80,10 +80,16 @@ GT_INTELLI_EXPORT void debug(Graph const& graph);
 GT_INTELLI_EXPORT void debug(ConnectionModel const& model);
 GT_INTELLI_EXPORT void debug(GlobalConnectionModel const& model);
 
+/**
+ * @brief Returns whether the list of nodes contains a node with the id `nodeId`.
+ * @tparam NodeId_t could be either NodeId or NodeUuid
+ * @param nodeId Id of the node to search for
+ * @param nodes Iterable list of nodes
+ * @return Whether the list contains a node with the desired id
+ */
 template <typename NodeId_t, typename NodeList>
 static bool containsNodeId(NodeId_t const& nodeId, NodeList const& nodes)
 {
-    // check if connection is internal
     auto iter = std::find_if(nodes.begin(), nodes.end(), [&nodeId](auto node){
         return nodeId == get_node_id<NodeId_t>{}(node);
     });

--- a/src/intelli/node.h
+++ b/src/intelli/node.h
@@ -749,6 +749,8 @@ struct get_node_id;
 template <>
 struct get_node_id<NodeId>
 {
+    template <typename T>
+    NodeId operator()(T const* o) { assert(o); return o->nodeId(); }
     NodeId operator()(Node const* node) { assert(node); return node->id(); }
     NodeId operator()(NodeId nodeId) { return nodeId; }
 };
@@ -756,6 +758,8 @@ struct get_node_id<NodeId>
 template <>
 struct get_node_id<NodeUuid>
 {
+    template <typename T>
+    NodeId operator()(T const* o) { assert(o); return o->nodeUuid(); }
     NodeUuid operator()(Node const* node) { assert(node); return node->uuid(); }
     NodeUuid operator()(NodeUuid nodeUuid) { return nodeUuid; }
 };

--- a/src/intelli/private/graph_impl.h
+++ b/src/intelli/private/graph_impl.h
@@ -466,12 +466,15 @@ struct Graph::Impl
 
             if (targetNode == model->end() || sourceNode == model->end())
             {
-                gtWarning() << utils::logId(*graph)
-                            << tr("Failed to delete connection %1")
-                                   .arg(toString(conId))
-                            << tr("(in-node entry %1, out-node entry %2!)")
-                                   .arg(targetNode != model->end() ? "found" : "not found")
-                                   .arg(sourceNode != model->end() ? "found" : "not found");
+                // global connection may already be deleted, but this function
+                // may still be triggered causing a false alarm
+                gtWarning().verbose()
+                    << utils::logId(*graph)
+                    << tr("Failed to delete connection %1")
+                           .arg(toString(conId))
+                    << tr("(in-node entry %1, out-node entry %2!)")
+                           .arg(targetNode != model->end() ? "found" : "not found")
+                           .arg(sourceNode != model->end() ? "found" : "not found");
                 return false;
             }
 


### PR DESCRIPTION
Closes #277 - fixed the instantiation of shared outgoing connections when grouping nodes which caused certain outgoing connections to disappear when grouping nodes.