### PR TITLE
Resolve: "Node::evaluated is triggered twice"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moving a node now creates an undo command. - #41
 
 ### Fixed
+- Fixed `Node::evaluated` being triggered twice per evaluation. - #278
 - Fixed instantiation of outgoing connections when grouping nodes. - #277
 - Fixed slider input mode for number input nodes not committing value. - #272
 - The overlay buttons in a graph scene no longer create undo/redo commands. - #271

--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -627,8 +627,6 @@ GraphExecutionModel::onNodeEvaluated(NodeUuid const& nodeUuid)
                .arg(relativeNodePath(*node))
                .arg(node->id());
 
-    emit node->evaluated();
-
     // update counter for running child nodes
     auto* graph = Graph::accessGraph(*node);
     Impl::propagateNodeEvalautionStatus<std::minus>(*this, graph);
@@ -639,8 +637,6 @@ GraphExecutionModel::onNodeEvaluated(NodeUuid const& nodeUuid)
     {
         INTELLI_LOG_SCOPE(*this)
             << tr("node requires reevaluation!");
-
-        emit node->evaluated();
 
         if (!evaluateNode(nodeUuid).detach())
         {


### PR DESCRIPTION
Closes #278 - `Node::evaluated` is no longer triggered twice