### PR TITLE
Resolve: "Collapse nodes visually"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Nodes can now be collapsed using the node's context menu. Collapsed nodes only consists of the node's header, reducing visual clutter. - #282
+
 ## [0.14.0] - 2025-04-04
 *This release is considered ABI compatible with `0.13.0`*
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,7 +120,9 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/graphstatemanager.h
     intelli/gui/graphview.h
     intelli/gui/graphviewoverlay.h
+    intelli/gui/guidata.h
     intelli/gui/ui/connectionui.h
+    intelli/gui/ui/guidataui.h
     intelli/gui/ui/graphcategoryui.h
     intelli/gui/ui/logicnodeui.h
     intelli/gui/ui/packageui.h
@@ -203,9 +205,11 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/graphstatemanager.cpp
     intelli/gui/graphview.cpp
     intelli/gui/graphviewoverlay.cpp
+    intelli/gui/guidata.cpp
     intelli/gui/icons.cpp
     intelli/gui/style.cpp
     intelli/gui/ui/connectionui.cpp
+    intelli/gui/ui/guidataui.cpp
     intelli/gui/ui/logicnodeui.cpp
     intelli/gui/ui/graphcategoryui.cpp
     intelli/gui/ui/packageui.cpp

--- a/src/intelli/dynamicnode.cpp
+++ b/src/intelli/dynamicnode.cpp
@@ -14,6 +14,7 @@
 #include "intelli/property/uint.h"
 #include "intelli/private/utils.h"
 
+#include "gt_propertystructcontainer.h"
 #include "gt_structproperty.h"
 #include "gt_stringproperty.h"
 #include "gt_boolproperty.h"

--- a/src/intelli/dynamicnode.h
+++ b/src/intelli/dynamicnode.h
@@ -12,9 +12,7 @@
 
 #include <intelli/node.h>
 
-#include <gt_propertystructcontainer.h>
-
-#include <QStringList>
+class GtPropertyStructInstance;
 
 namespace intelli
 {

--- a/src/intelli/graph.cpp
+++ b/src/intelli/graph.cpp
@@ -16,6 +16,7 @@
 #include "intelli/node/dummy.h"
 #include "intelli/node/groupinputprovider.h"
 #include "intelli/node/groupoutputprovider.h"
+#include "intelli/gui/guidata.h"
 
 #include <gt_qtutilities.h>
 #include <gt_algorithms.h>
@@ -31,12 +32,15 @@ Graph::Graph() :
     // we create the node connections here in this group object. This way
     // merging mementos has the correct order (first the connections are removed
     // then the nodes)
-    auto* group = new ConnectionGroup(this);
-    group->setDefault(true);
+    auto* connectionGroup = new ConnectionGroup(this);
+    connectionGroup->setDefault(true);
+
+    auto* guiData = new GuiData(this);
+    guiData->setDefault(true);
 
     setNodeEvalMode(NodeEvalMode::Blocking);
 
-    connect(group, &ConnectionGroup::mergeConnections, this, [this](){
+    connect(connectionGroup, &ConnectionGroup::mergeConnections, this, [this](){
         restoreConnections();
     });
 }

--- a/src/intelli/graphconnectionmodel.h
+++ b/src/intelli/graphconnectionmodel.h
@@ -168,6 +168,17 @@ inline auto makeProxy(T const& t, Proxy p = {})
 }
 
 /**
+ * @brief Helper method that instantiates an iterable object based on `t`'s
+ * reverse begin and end operator. A default proxy object is installed that
+ * yields the underlying value type.
+ */
+template <typename T>
+inline auto makeReverseIter(T&& t)
+{
+    return makeProxy(t.rbegin(), t.rend(), DefaultProxy<typename std::decay_t<T>::value_type>{});
+}
+
+/**
  * @brief Helper struct that allows the use of for-range based loops and similar
  * constructs
  */

--- a/src/intelli/gui/graphics/nodeobject.cpp
+++ b/src/intelli/gui/graphics/nodeobject.cpp
@@ -227,6 +227,9 @@ NodeGraphicsObject::collapse(bool doCollapse)
     if (centralWidget()) centralWidget()->setVisible(!doCollapse);
 
     pimpl->collapsed = doCollapse;
+
+    emit nodeCollapsed(this, doCollapse);
+
     Impl::prepareGeometryChange(this).finalize();
 }
 

--- a/src/intelli/gui/graphics/nodeobject.cpp
+++ b/src/intelli/gui/graphics/nodeobject.cpp
@@ -224,6 +224,8 @@ NodeGraphicsObject::isCollpased() const
 void
 NodeGraphicsObject::collapse(bool doCollapse)
 {
+    if (pimpl->collapsed == doCollapse) return; // nothing to do
+
     if (centralWidget()) centralWidget()->setVisible(!doCollapse);
 
     pimpl->collapsed = doCollapse;

--- a/src/intelli/gui/graphics/nodeobject.cpp
+++ b/src/intelli/gui/graphics/nodeobject.cpp
@@ -94,6 +94,8 @@ struct NodeGraphicsObject::Impl
     State state = Normal;
     /// Whether node is hovered
     bool hovered = false;
+    /// Whether the node is collapsed
+    bool collapsed = false;
 
     Impl(NodeGraphicsObject* obj, GraphSceneData& data_, Node& node_) :
         sceneData(&data_),
@@ -211,6 +213,21 @@ bool
 NodeGraphicsObject::isHovered() const
 {
     return pimpl->hovered;
+}
+
+bool
+NodeGraphicsObject::isCollpased() const
+{
+    return pimpl->collapsed;
+}
+
+void
+NodeGraphicsObject::collapse(bool doCollapse)
+{
+    if (centralWidget()) centralWidget()->setVisible(!doCollapse);
+
+    pimpl->collapsed = doCollapse;
+    Impl::prepareGeometryChange(this).finalize();
 }
 
 bool

--- a/src/intelli/gui/graphics/nodeobject.h
+++ b/src/intelli/gui/graphics/nodeobject.h
@@ -93,11 +93,17 @@ public:
      */
     bool isHovered() const;
 
-    /// TODO
+    /**
+     * @brief Returns whether this node is collapsed (node's body is hidden).
+     * @return Is collapsed
+     */
     bool isCollpased() const;
 
-    /// TODO
-    Q_INVOKABLE void collapse(bool doCollapse);
+    /**
+     * @brief Sets the collapsed state of this node (hides node's body).
+     * @param doCollapse Whether the node should be collapsed
+     */
+    void collapse(bool doCollapse = true);
 
     /**
      * @brief Whether the resize handle should be displayed
@@ -243,8 +249,9 @@ signals:
     void makeDraftConnection(NodeGraphicsObject* object, PortType type, PortId port);
 
     /**
-     * @brief Emitted if the node was shifted (moved by x,y).
-     * @param object Object that was moved
+     * @brief Emitted if the node was shifted (moved by x,y). The user is still
+     * moving the node
+     * @param object Object that was moved (this)
      * @param diff Difference that the object was moved by
      */
     void nodeShifted(NodeGraphicsObject* object, QPointF diff);
@@ -252,25 +259,49 @@ signals:
     /**
      * @brief Emitted once the node was moved to its "final" postion (i.e. the
      * user no longer has ended the move operation)
-     * @param object Object that was moved
+     * @param object Object that was moved (this)
      */
     void nodeMoved(NodeGraphicsObject* object);
 
     /**
      * @brief Emitted once a node's position was updated externally (i.e. NOT
      * by moving the node's graphics objec)
-     * @param object Object that updated its position
+     * @param object Object that updated its position (this)
      */
     void nodePositionChanged(NodeGraphicsObject* object);
 
+    /**
+     * @brief Emitted once the node was collapsed or expanded.
+     * @param object Object that was collapsed (this)
+     * @param isCollapsed Whether the node was collapsed or expanded
+     */
     void nodeCollapsed(NodeGraphicsObject* object, bool isCollapsed);
 
+    /**
+     * @brief Emitted once the node was double clicked
+     * @param object Object that was double clicked (this)
+     */
     void nodeDoubleClicked(NodeGraphicsObject* object);
 
+    /**
+     * @brief Emitted once the node's changed its geometry and was updated.
+     * @param object Object that was double clicked (this)
+     */
     void nodeGeometryChanged(NodeGraphicsObject* object);
 
+    /**
+     * @brief Emitted once the context menu of a port was requested
+     * @param object Object for which the port's context menu was requested (this)
+     * @param port Port for which the context menu should be requested
+     * @param pos Local cursor position
+     */
     void portContextMenuRequested(NodeGraphicsObject* object, PortId port, QPointF pos);
 
+    /**
+     * @brief Emitted once the context menu of a node was requested
+     * @param object Object for which the context menu was requested (this)
+     * @param pos Local cursor position
+     */
     void contextMenuRequested(NodeGraphicsObject* object, QPointF pos);
 
 private:

--- a/src/intelli/gui/graphics/nodeobject.h
+++ b/src/intelli/gui/graphics/nodeobject.h
@@ -93,6 +93,12 @@ public:
      */
     bool isHovered() const;
 
+    /// TODO
+    bool isCollpased() const;
+
+    /// TODO
+    void collapse(bool doCollapse);
+
     /**
      * @brief Whether the resize handle should be displayed
      * @return Has resize handle

--- a/src/intelli/gui/graphics/nodeobject.h
+++ b/src/intelli/gui/graphics/nodeobject.h
@@ -97,7 +97,7 @@ public:
     bool isCollpased() const;
 
     /// TODO
-    void collapse(bool doCollapse);
+    Q_INVOKABLE void collapse(bool doCollapse);
 
     /**
      * @brief Whether the resize handle should be displayed
@@ -262,6 +262,8 @@ signals:
      * @param object Object that updated its position
      */
     void nodePositionChanged(NodeGraphicsObject* object);
+
+    void nodeCollapsed(NodeGraphicsObject* object, bool isCollapsed);
 
     void nodeDoubleClicked(NodeGraphicsObject* object);
 

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -1651,8 +1651,12 @@ GraphScene::onNodeAppended(Node* node)
             this, &GraphScene::onMakeDraftConnection,
             Qt::DirectConnection);
 
+    auto* entityPtr = entity.get();
+
     // append to map
     m_nodes.push_back({node->id(), std::move(entity)});
+
+    emit nodeAppended(entityPtr);
 }
 
 void

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -1611,6 +1611,19 @@ void
 GraphScene::collapseNodes(QVector<NodeGraphicsObject*> const& selectedNodeObjects,
                           bool doCollapse)
 {
+    if (selectedNodeObjects.empty()) return;
+
+    QString caption =
+        relativeNodePath(selectedNodeObjects.front()->node()) +
+        (selectedNodeObjects.size() > 1 ? ", ...":"");
+
+    auto change = gtApp->makeCommand(&graph(),
+                                     tr("Node%1 %2collapsed (%3)")
+                                         .arg(selectedNodeObjects.size() > 1 ? "s":"",
+                                              doCollapse? "":"un",
+                                              caption));
+    Q_UNUSED(change);
+
     for (NodeGraphicsObject* o : selectedNodeObjects)
     {
         o->collapse(doCollapse);
@@ -1651,12 +1664,8 @@ GraphScene::onNodeAppended(Node* node)
             this, &GraphScene::onMakeDraftConnection,
             Qt::DirectConnection);
 
-    auto* entityPtr = entity.get();
-
     // append to map
     m_nodes.push_back({node->id(), std::move(entity)});
-
-    emit nodeAppended(entityPtr);
 }
 
 void

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -95,14 +95,22 @@ isNotDeletable(NodeGraphicsObject* o)
     return !(o->node().objectFlags() & GtObject::ObjectFlag::UserDeletable);
 };
 
-// TODO
+/**
+ * @brief Helper method that yields whether a node is collapsed
+ * @param o Object
+ * @return Whether the node is collapsed
+ */
 static bool
 isCollapsed(NodeGraphicsObject* o)
 {
     return o->isCollpased();
 };
 
-// TODO
+/**
+ * @brief Negates the result of a functor.
+ * @param func Functor, must yield a boolean compatible value and accept the
+ * pointer to a node graphics object as an argument.
+ */
 template <typename Func>
 static auto
 negate(Func func)
@@ -1617,11 +1625,13 @@ GraphScene::collapseNodes(QVector<NodeGraphicsObject*> const& selectedNodeObject
         relativeNodePath(selectedNodeObjects.front()->node()) +
         (selectedNodeObjects.size() > 1 ? ", ...":"");
 
-    auto change = gtApp->makeCommand(&graph(),
-                                     tr("Node%1 %2collapsed (%3)")
-                                         .arg(selectedNodeObjects.size() > 1 ? "s":"",
-                                              doCollapse? "":"un",
-                                              caption));
+    auto change = gtApp->makeCommand(
+        &graph(),
+        tr("Node%1 %2collapsed (%3)")
+            .arg(selectedNodeObjects.size() > 1 ? "s":"",
+                 doCollapse? "":"un",
+                 caption)
+    );
     Q_UNUSED(change);
 
     for (NodeGraphicsObject* o : selectedNodeObjects)

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -95,6 +95,23 @@ isNotDeletable(NodeGraphicsObject* o)
     return !(o->node().objectFlags() & GtObject::ObjectFlag::UserDeletable);
 };
 
+// TODO
+static bool
+isCollapsed(NodeGraphicsObject* o)
+{
+    return o->isCollpased();
+};
+
+// TODO
+template <typename Func>
+static auto
+negate(Func func)
+{
+    return [f = std::move(func)](NodeGraphicsObject* o) -> bool {
+        return !f(o);
+    };
+};
+
 /**
  * @brief Returns a functor that searches for the targeted `nodeId`
  * @param nodeId
@@ -1128,6 +1145,14 @@ GraphScene::onNodeContextMenu(NodeGraphicsObject* object, QPointF pos)
                                      selected.nodes.end(),
                                      Impl::isNotDeletable);
 
+    bool someCollapsed = std::any_of(selected.nodes.begin(),
+                                     selected.nodes.end(),
+                                     Impl::isCollapsed);
+
+    bool someUncollapsed = std::any_of(selected.nodes.begin(),
+                                       selected.nodes.end(),
+                                       Impl::negate(Impl::isCollapsed));
+
     Node* selectedNode = &selected.nodes.at(0)->node();
     assert(selectedNode);
     Graph* selectedGraphNode = NodeUI::toGraph(selectedNode);
@@ -1143,6 +1168,14 @@ GraphScene::onNodeContextMenu(NodeGraphicsObject* object, QPointF pos)
     QAction* groupAction = menu.addAction(tr("Group selected Nodes"));
     groupAction->setIcon(gt::gui::icon::select());
     groupAction->setEnabled(allDeletable);
+
+    QAction* collapseAction = menu.addAction(tr("Collapse selected Nodes"));
+    collapseAction->setIcon(gt::gui::icon::triangleUp());
+    collapseAction->setVisible(someUncollapsed);
+
+    QAction* uncollapseAction = menu.addAction(tr("Uncollapse selected Nodes"));
+    uncollapseAction->setIcon(gt::gui::icon::triangleDown());
+    uncollapseAction->setVisible(someCollapsed);
 
     menu.addSeparator();
 
@@ -1167,6 +1200,11 @@ GraphScene::onNodeContextMenu(NodeGraphicsObject* object, QPointF pos)
     if (triggered == ungroupAction)
     {
         return expandGroupNode(selectedGraphNode);
+    }
+    if (triggered == collapseAction ||
+        triggered == uncollapseAction)
+    {
+        return collapseNodes(selected.nodes, triggered == collapseAction);
     }
     if (triggered == deleteAction)
     {
@@ -1567,6 +1605,16 @@ GraphScene::expandGroupNode(Graph* groupNode)
     }
 
     restoreCmd.clear();
+}
+
+void
+GraphScene::collapseNodes(QVector<NodeGraphicsObject*> const& selectedNodeObjects,
+                          bool doCollapse)
+{
+    for (NodeGraphicsObject* o : selectedNodeObjects)
+    {
+        o->collapse(doCollapse);
+    }
 }
 
 void

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -102,6 +102,8 @@ signals:
 
     void snapToGridChanged();
 
+    void nodeAppended(NodeGraphicsObject* object);
+
 protected:
 
     void keyPressEvent(QKeyEvent* event) override;

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -143,9 +143,15 @@ private:
     /// Currently active command when moving nodes
     GtCommand m_nodeMoveCmd = {};
 
+    /// TODO
     void groupNodes(QVector<NodeGraphicsObject*> const& selectedNodeObjects);
 
+    /// TODO
     void expandGroupNode(Graph* groupNode);
+
+    /// TODO
+    void collapseNodes(QVector<NodeGraphicsObject*> const& selectedNodeObjects,
+                       bool doCollapse);
 
     /**
      * @brief Updates the connection's end points. If a node graphics object

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -143,13 +143,27 @@ private:
     /// Currently active command when moving nodes
     GtCommand m_nodeMoveCmd = {};
 
-    /// TODO
+    /**
+     * @brief Groups the selected nodes by moving the into a subgraph.
+     * Instantiates ingoing and outgoing connections. Nodes and internal
+     * connections are preserved.
+     * @param selectedNodeObjects Nodes that should be grouped
+     */
     void groupNodes(QVector<NodeGraphicsObject*> const& selectedNodeObjects);
 
-    /// TODO
+    /**
+     * @brief Expands the selected subgraph. Its nodes and internal
+     * connections are preserved (except for the input/outputproviders).
+     * Instantiates ingoing and outgoing connections.
+     * @param groupNode Subgraph that should be expanded
+     */
     void expandGroupNode(Graph* groupNode);
 
-    /// TODO
+    /**
+     * @brief Collapsed/expands the selected nodes
+     * @param selectedNodeObjects Nodes that should be collapsed/expanded
+     * @param doCollapse Whether the nodes should be collapsed or expanded
+     */
     void collapseNodes(QVector<NodeGraphicsObject*> const& selectedNodeObjects,
                        bool doCollapse);
 

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -102,8 +102,6 @@ signals:
 
     void snapToGridChanged();
 
-    void nodeAppended(NodeGraphicsObject* object);
-
 protected:
 
     void keyPressEvent(QKeyEvent* event) override;

--- a/src/intelli/gui/graphstatemanager.cpp
+++ b/src/intelli/gui/graphstatemanager.cpp
@@ -167,12 +167,12 @@ GraphStateManager::setupLocalStates(GraphScene* scene)
 
         QObject::connect(object, &NodeGraphicsObject::nodeCollapsed,
                          localStates, onValueChanged);
+
+        object->collapse(localStates->isNodeCollapsed(node->uuid()));
     };
 
     QObject::connect(localStates, &LocalStateContainer::nodeCollapsedChanged,
                      scene, onStateChanged);
-
-    localStates->init();
 
     connect(&graph, &Graph::nodeAppended, this, onNodeAppended);
 

--- a/src/intelli/gui/graphstatemanager.h
+++ b/src/intelli/gui/graphstatemanager.h
@@ -57,6 +57,10 @@ private:
     QPointer<GraphView> m_view;
 
     unique_qptr<GtObject> m_guardian;
+
+    void setupUserStates(GraphScene* scene);
+
+    void setupLocalStates(GraphScene* scene);
 };
 
 } // namespace intelli

--- a/src/intelli/gui/graphstatemanager.h
+++ b/src/intelli/gui/graphstatemanager.h
@@ -58,8 +58,18 @@ private:
 
     unique_qptr<GtObject> m_guardian;
 
+    /**
+     * @brief Instantiates all global (=user specific) states. These states
+     * are not shared with other users e.g. by exchanging the project files.
+     * @param scene Scene
+     */
     void setupUserStates(GraphScene* scene);
 
+    /**
+     * @brief Instantiates all states specific to a graph. These states are
+     * stored within the project files
+     * @param scene Scene
+     */
     void setupLocalStates(GraphScene* scene);
 };
 

--- a/src/intelli/gui/guidata.cpp
+++ b/src/intelli/gui/guidata.cpp
@@ -1,0 +1,114 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#include <intelli/graph.h>
+#include <intelli/gui/guidata.h>
+
+#include <gt_application.h>
+#include <gt_structproperty.h>
+
+#include <gt_stringproperty.h>
+
+using namespace intelli;
+
+GuiData::GuiData(GtObject* parent) :
+    GtObject(parent)
+{
+    setObjectName(tr("__gui_data"));
+
+    auto* localStates = new LocalStateContainer(this);
+    localStates->setDefault(true);
+
+    if (!gtApp || !gtApp->devMode()) setFlag(UserHidden);
+}
+
+LocalStateContainer*
+GuiData::accessLocalStates(Graph& graph)
+{
+    auto* guiData = graph.findDirectChild<GuiData*>();
+    if (!guiData) return {};
+
+    return guiData->findDirectChild<LocalStateContainer*>();
+}
+
+char const* S_TYPE_ID = "Collapsed";
+
+LocalStateContainer::LocalStateContainer(GtObject* parent) :
+    GtObject(parent),
+    m_collapsed("collapsed", tr("Collapsed Nodes"))
+{
+    setObjectName(tr("local_states"));
+
+    // presence of struct inidcates node is collapsed
+    GtPropertyStructDefinition structType{S_TYPE_ID};
+    m_collapsed.registerAllowedType(structType);
+
+    registerPropertyStructContainer(m_collapsed);
+
+    connect(&m_collapsed, &GtPropertyStructContainer::entryAdded,
+            this, [this](int idx){
+                GtPropertyStructInstance& entry = m_collapsed.at(idx);
+                m_collapsedMap.insert(idx, entry.ident());
+                emit nodeCollapsedChanged(entry.ident(), true);
+                assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+            }, Qt::DirectConnection);
+
+    connect(&m_collapsed, &GtPropertyStructContainer::entryRemoved,
+            this, [this](int idx){
+                NodeUuid nodeUuid = m_collapsedMap.at(idx);
+                m_collapsedMap.removeAt(idx);
+                emit nodeCollapsedChanged(nodeUuid, false);
+                assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+        }, Qt::DirectConnection);
+}
+
+void
+LocalStateContainer::init()
+{
+    assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+    for (GtPropertyStructInstance const& e : m_collapsed)
+    {
+        emit nodeCollapsedChanged(e.ident(), true);
+    }
+}
+
+void
+LocalStateContainer::setNodeCollapsed(NodeUuid const& nodeUuid, bool collapsed)
+{
+    if (collapsed == isNodeCollapsed(nodeUuid)) return;
+
+    if (collapsed)
+    {
+        m_collapsed.newEntry(S_TYPE_ID,
+                             std::next(m_collapsed.begin(), m_collapsed.size()),
+                             nodeUuid);
+        assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+        return;
+    }
+
+    auto iter = std::find_if(m_collapsed.begin(), m_collapsed.end(),
+                             [&nodeUuid](GtPropertyStructInstance const& e){
+                                 return e.ident()  == nodeUuid;
+                             });
+    if (iter == m_collapsed.end()) return;
+
+    m_collapsed.removeEntry(iter);
+    assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+}
+
+bool
+LocalStateContainer::isNodeCollapsed(NodeUuid const& nodeUuid) const
+{
+    assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+    return std::find_if(m_collapsed.begin(), m_collapsed.end(),
+                        [&nodeUuid](GtPropertyStructInstance const& e){
+                            return e.ident()  == nodeUuid;
+                        }) != m_collapsed.end();
+}
+

--- a/src/intelli/gui/guidata.cpp
+++ b/src/intelli/gui/guidata.cpp
@@ -45,7 +45,7 @@ LocalStateContainer::LocalStateContainer(GtObject* parent) :
 {
     setObjectName(tr("local_states"));
 
-    // presence of struct inidcates node is collapsed
+    // presence of struct indicates that the node is collapsed
     GtPropertyStructDefinition structType{S_TYPE_ID};
     m_collapsed.registerAllowedType(structType);
 
@@ -53,29 +53,19 @@ LocalStateContainer::LocalStateContainer(GtObject* parent) :
 
     connect(&m_collapsed, &GtPropertyStructContainer::entryAdded,
             this, [this](int idx){
-                GtPropertyStructInstance& entry = m_collapsed.at(idx);
-                m_collapsedMap.insert(idx, entry.ident());
-                emit nodeCollapsedChanged(entry.ident(), true);
-                assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
-            }, Qt::DirectConnection);
+        GtPropertyStructInstance& entry = m_collapsed.at(idx);
+        m_collapsedData.insert(idx, entry.ident());
+        emit nodeCollapsedChanged(entry.ident(), true);
+        assert(m_collapsed.size() == (size_t)m_collapsedData.size());
+    }, Qt::DirectConnection);
 
     connect(&m_collapsed, &GtPropertyStructContainer::entryRemoved,
             this, [this](int idx){
-                NodeUuid nodeUuid = m_collapsedMap.at(idx);
-                m_collapsedMap.removeAt(idx);
-                emit nodeCollapsedChanged(nodeUuid, false);
-                assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
-        }, Qt::DirectConnection);
-}
-
-void
-LocalStateContainer::init()
-{
-    assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
-    for (GtPropertyStructInstance const& e : m_collapsed)
-    {
-        emit nodeCollapsedChanged(e.ident(), true);
-    }
+        NodeUuid nodeUuid = m_collapsedData.at(idx);
+        m_collapsedData.removeAt(idx);
+        emit nodeCollapsedChanged(nodeUuid, false);
+        assert(m_collapsed.size() == (size_t)m_collapsedData.size());
+    }, Qt::DirectConnection);
 }
 
 void
@@ -85,10 +75,8 @@ LocalStateContainer::setNodeCollapsed(NodeUuid const& nodeUuid, bool collapsed)
 
     if (collapsed)
     {
-        m_collapsed.newEntry(S_TYPE_ID,
-                             std::next(m_collapsed.begin(), m_collapsed.size()),
-                             nodeUuid);
-        assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+        m_collapsed.newEntry(S_TYPE_ID, nodeUuid);
+        assert(m_collapsed.size() == (size_t)m_collapsedData.size());
         return;
     }
 
@@ -99,16 +87,16 @@ LocalStateContainer::setNodeCollapsed(NodeUuid const& nodeUuid, bool collapsed)
     if (iter == m_collapsed.end()) return;
 
     m_collapsed.removeEntry(iter);
-    assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+    assert(m_collapsed.size() == (size_t)m_collapsedData.size());
 }
 
 bool
 LocalStateContainer::isNodeCollapsed(NodeUuid const& nodeUuid) const
 {
-    assert(m_collapsed.size() == (size_t)m_collapsedMap.size());
+    assert(m_collapsed.size() == (size_t)m_collapsedData.size());
     return std::find_if(m_collapsed.begin(), m_collapsed.end(),
                         [&nodeUuid](GtPropertyStructInstance const& e){
-                            return e.ident()  == nodeUuid;
-                        }) != m_collapsed.end();
+        return e.ident()  == nodeUuid;
+    }) != m_collapsed.end();
 }
 

--- a/src/intelli/gui/guidata.h
+++ b/src/intelli/gui/guidata.h
@@ -12,7 +12,6 @@
 
 #include <intelli/globals.h>
 
-#include <gt_state.h>
 #include <gt_object.h>
 #include <gt_propertystructcontainer.h>
 
@@ -22,6 +21,9 @@ namespace intelli
 class Graph;
 class LocalStateContainer;
 
+/**
+ * @brief The GuiData class. Base object for GUI-specific data
+ */
 class GuiData : public GtObject
 {
     Q_OBJECT
@@ -33,6 +35,10 @@ public:
     static LocalStateContainer* accessLocalStates(Graph& graph);
 };
 
+/**
+ * @brief The LocalStateContainer class. Data object for storing states
+ * specific to a graph.
+ */
 class LocalStateContainer : public GtObject
 {
     Q_OBJECT
@@ -41,21 +47,37 @@ public:
 
     Q_INVOKABLE LocalStateContainer(GtObject* parent = nullptr);
 
-    void init();
-
+    /**
+     * @brief Sets the collapsed state for the given node.
+     * @param nodeUuid Node's Uuid
+     * @param collapsed Whether the node is collapsed or expanded
+     */
     void setNodeCollapsed(NodeUuid const& nodeUuid, bool collapsed = true);
 
+    /**
+     * @brief Returns whether the node is collapsed or expanded
+     * @param nodeUuid Node's Uuid
+     * @return Whether the node is collapsed or expanded
+     */
     bool isNodeCollapsed(NodeUuid const& nodeUuid) const;
 
 signals:
 
+    /**
+     * @brief Emitted once the node changes its collapsed state
+     * @param nodeUuid Node's Uuid
+     * @param isCollapsed Whether node is collapsed or not
+     */
     void nodeCollapsedChanged(QString const& nodeUuid, bool isCollapsed);
 
 private:
 
+    /// Struct container for storing all nodes that are collapsed.
+    /// Nodes that are not present are expanded.
     GtPropertyStructContainer m_collapsed;
 
-    QStringList m_collapsedMap;
+    /// TODO: remove me once core issue #1366 is merged
+    QStringList m_collapsedData;
 };
 
 } // namespace intelli

--- a/src/intelli/gui/guidata.h
+++ b/src/intelli/gui/guidata.h
@@ -1,0 +1,63 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#ifndef GT_INTELLI_GUIDATA_H
+#define GT_INTELLI_GUIDATA_H
+
+#include <intelli/globals.h>
+
+#include <gt_state.h>
+#include <gt_object.h>
+#include <gt_propertystructcontainer.h>
+
+namespace intelli
+{
+
+class Graph;
+class LocalStateContainer;
+
+class GuiData : public GtObject
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE GuiData(GtObject* parent = nullptr);
+
+    static LocalStateContainer* accessLocalStates(Graph& graph);
+};
+
+class LocalStateContainer : public GtObject
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE LocalStateContainer(GtObject* parent = nullptr);
+
+    void init();
+
+    void setNodeCollapsed(NodeUuid const& nodeUuid, bool collapsed = true);
+
+    bool isNodeCollapsed(NodeUuid const& nodeUuid) const;
+
+signals:
+
+    void nodeCollapsedChanged(QString const& nodeUuid, bool isCollapsed);
+
+private:
+
+    GtPropertyStructContainer m_collapsed;
+
+    QStringList m_collapsedMap;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_GUIDATA_H

--- a/src/intelli/gui/nodegeometry.cpp
+++ b/src/intelli/gui/nodegeometry.cpp
@@ -327,6 +327,7 @@ NodeGeometry::portRect(PortType type, PortIndex idx) const
 
     if (object().isCollpased())
     {
+        // position port at vertical center if collapsed
         int height = body.height() * 0.5 - style.portRadius;
 
         return QRectF{

--- a/src/intelli/gui/nodegeometry.cpp
+++ b/src/intelli/gui/nodegeometry.cpp
@@ -52,6 +52,12 @@ NodeGeometry::vspacing() const
     return 0.5 * hspacing();
 }
 
+bool
+NodeGeometry::hasDisplayIcon() const
+{
+    return uiData().hasDisplayIcon() || object().isCollpased();
+}
+
 int
 NodeGeometry::portHorizontalExtent(PortType type) const
 {
@@ -146,6 +152,8 @@ NodeGeometry::computeNodeHeaderRect() const
 QRectF
 NodeGeometry::nodeBodyRect() const
 {
+    if (object().isCollpased()) return nodeHeaderRect();
+
     if (m_bodyRect.has_value()) return *m_bodyRect;
 
     // set empty value to avoid cyclic calls
@@ -243,7 +251,7 @@ NodeGeometry::iconRect() const
 QSize
 NodeGeometry::iconSize() const
 {
-    if (!uiData().hasDisplayIcon()) return QSize{0, 0};
+    if (!hasDisplayIcon()) return QSize{0, 0};
 
     auto& style = style::currentStyle().node;
     return QSize{style.iconSize, style.iconSize};
@@ -268,7 +276,7 @@ NodeGeometry::evalStateSize() const
 QPointF
 NodeGeometry::widgetPosition() const
 {
-    if (!centralWidget()) return {};
+    if (!centralWidget() || object().isCollpased()) return {};
 
     auto body = nodeBodyRect();
 
@@ -296,8 +304,9 @@ NodeGeometry::widgetPosition() const
 QSize
 NodeGeometry::widgetSize() const
 {
-    if (auto* w = centralWidget()) return w->size();
-    return {};
+    auto* w = centralWidget();
+    if (!w || object().isCollpased()) return {};
+    return w->size();
 }
 
 QRectF
@@ -310,10 +319,24 @@ NodeGeometry::portRect(PortType type, PortIndex idx) const
     auto& node = this->node();
     auto& style = style::currentStyle().node;
 
-    QFontMetrics metrcis(style.bodyFont);
+    auto body = nodeBodyRect();
+
+    // width
+    double width = type == PortType::Out ? body.width() : 0.0;
+    width -= style.portRadius;
+
+    if (object().isCollpased())
+    {
+        int height = body.height() * 0.5 - style.portRadius;
+
+        return QRectF{
+            QPointF(width, height),
+            QSizeF{style.portRadius * 2, style.portRadius * 2}
+        };
+    }
 
     // height
-    auto body = nodeBodyRect();
+    QFontMetrics metrcis(style.bodyFont);
     int offset = metrcis.height() * 0.6;
     int height = body.topLeft().y() + vspacing() + style.portRadius;
 
@@ -329,11 +352,6 @@ NodeGeometry::portRect(PortType type, PortIndex idx) const
         height += 2 * offset + vspacing();
     }
 
-
-    // width
-    double width = type == PortType::Out ? body.width() : 0.0;
-    width -= style.portRadius;
-
     return QRectF{
         QPointF(width, height),
         QSizeF{style.portRadius * 2, style.portRadius * 2}
@@ -346,6 +364,8 @@ NodeGeometry::portCaptionRect(PortType type, PortIndex idx) const
     // bounds check
     assert(type != PortType::NoType);
     if (node().ports(type).size() < idx) return {};
+
+    if (object().isCollpased()) return {};
 
     auto& style = style::currentStyle().node;
     auto& node  = this->node();
@@ -390,6 +410,8 @@ NodeGeometry::portHit(QPointF coord) const
 NodeGeometry::PortHit
 NodeGeometry::portHit(QRectF rect) const
 {
+    if (object().isCollpased()) return {};
+
     auto body  = nodeBodyRect();
     auto coord = rect.center();
 

--- a/src/intelli/gui/nodegeometry.h
+++ b/src/intelli/gui/nodegeometry.h
@@ -83,8 +83,8 @@ public:
 
     /**
      * @brief Returns whether the node should draw a display icon.
-     * This function respects `object().isCollapsed()` compared to
-     * `uiData().hasDisplayIcon`.
+     * This function respects collapsed-state of the node and may override
+     * `uiData().hasDisplayIcon()`.
      * @return Whether a display icon should be drawn
      */
     bool hasDisplayIcon() const;

--- a/src/intelli/gui/nodegeometry.h
+++ b/src/intelli/gui/nodegeometry.h
@@ -81,6 +81,8 @@ public:
      */
     int vspacing() const;
 
+    bool hasDisplayIcon() const;
+
     /**
      * @brief Returns the shape, which is used for the collision detection of
      * the actual graphics object. It should be accurate but not too complex.

--- a/src/intelli/gui/nodegeometry.h
+++ b/src/intelli/gui/nodegeometry.h
@@ -81,6 +81,12 @@ public:
      */
     int vspacing() const;
 
+    /**
+     * @brief Returns whether the node should draw a display icon.
+     * This function respects `object().isCollapsed()` compared to
+     * `uiData().hasDisplayIcon`.
+     * @return Whether a display icon should be drawn
+     */
     bool hasDisplayIcon() const;
 
     /**

--- a/src/intelli/gui/nodepainter.cpp
+++ b/src/intelli/gui/nodepainter.cpp
@@ -126,6 +126,16 @@ NodePainter::backgroundColor() const
     return bg;
 }
 
+QIcon
+NodePainter::displayIcon() const
+{
+    if (!geometry().hasDisplayIcon()) return {};
+
+    return object().isCollpased() ?
+               gt::gui::icon::triangleUp() :
+               uiData().displayIcon();
+}
+
 QColor
 NodePainter::customBackgroundColor() const
 {
@@ -291,13 +301,10 @@ NodePainter::drawResizeHandle(QPainter& painter) const
 void
 NodePainter::drawIcon(QPainter& painter) const
 {
-    if (!geometry().hasDisplayIcon()) return;
+    QIcon icon = displayIcon();
+    if (icon.isNull()) return;
 
     QRect rect = geometry().iconRect();
-
-    QIcon icon = object().isCollpased() ?
-                     gt::gui::icon::triangleUp() :
-                     uiData().displayIcon();
 
     icon.paint(&painter, rect);
 }

--- a/src/intelli/gui/nodepainter.h
+++ b/src/intelli/gui/nodepainter.h
@@ -44,11 +44,11 @@ public:
     {
         NoPortFlag = 0,
         /// Whether the port is connected
-        PortConnected = 1,
+        PortConnected = 1 << 0,
         /// Whether ports should be highlighted at all
-        HighlightPorts = 2,
+        HighlightPorts = 1 << 1,
         /// Whether the port should be highlighted. Check `HighlightPorts` first
-        PortHighlighted = 4,
+        PortHighlighted = 1 << 2
     };
 
     /**
@@ -72,12 +72,18 @@ public:
     void applyBackgroundConfig(QPainter& painter) const;
 
     /**
-     * @brief Applies pen and brush to the painter to render the outlne
+     * @brief Applies pen and brush to the painter to render the outline
      * of the node uniformly.
      * @param painter Painter to configure
      */
     void applyOutlineConfig(QPainter& painter) const;
 
+    /**
+     * @brief Applies pen and brush to the painter to render a port based on
+     * the port properties uniformly.
+     * of the node uniformly.
+     * @param painter Painter to configure
+     */
     void applyPortConfig(QPainter& painter,
                          PortInfo const& port,
                          PortType type,

--- a/src/intelli/gui/nodepainter.h
+++ b/src/intelli/gui/nodepainter.h
@@ -100,6 +100,14 @@ public:
     QColor backgroundColor() const;
 
     /**
+     * @brief Returns the icon that should be displayed in the node's header.
+     * This function respects the collapsed-state of the node and may override
+     * `uiData().displayIcon()`.
+     * @return Whether a display icon should be drawn
+     */
+    QIcon displayIcon() const;
+
+    /**
      * @brief Draws the background of the node.
      * @param painter Painter to draw with
      */

--- a/src/intelli/gui/nodepainter.h
+++ b/src/intelli/gui/nodepainter.h
@@ -78,6 +78,12 @@ public:
      */
     void applyOutlineConfig(QPainter& painter) const;
 
+    void applyPortConfig(QPainter& painter,
+                         PortInfo const& port,
+                         PortType type,
+                         PortIndex idx,
+                         uint flags) const;
+
     /**
      * @brief Returns the the background color of the node. Additional effects
      * may be applied. Override `customBackgroundColor` to apply a custom

--- a/src/intelli/gui/nodepainter.h
+++ b/src/intelli/gui/nodepainter.h
@@ -197,6 +197,8 @@ private:
     NodeGeometry const* m_geometry;
     /// padding
     alignas(8) uint8_t __padding[16];
+
+    void drawBackgroundHelper(QPainter& painter) const;
 };
 
 } // namespace intelli

--- a/src/intelli/gui/ui/guidataui.cpp
+++ b/src/intelli/gui/ui/guidataui.cpp
@@ -1,0 +1,23 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#include <intelli/gui/ui/guidataui.h>
+
+#include "gt_icons.h"
+
+using namespace intelli;
+
+GuiDataUI::GuiDataUI() = default;
+
+QIcon
+GuiDataUI::icon(GtObject* obj) const
+{
+    return gt::gui::icon::data();
+}
+

--- a/src/intelli/gui/ui/guidataui.h
+++ b/src/intelli/gui/ui/guidataui.h
@@ -1,0 +1,31 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2024 German Aerospace Center
+ *
+ *  Author: Marius Bröcker <marius.broecker@dlr.de>
+ */
+
+#ifndef GT_INTELLI_GUIDATAUI_H
+#define GT_INTELLI_GUIDATAUI_H
+
+#include <gt_objectui.h>
+
+namespace intelli
+{
+
+class GuiDataUI : public GtObjectUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE GuiDataUI();
+
+    QIcon icon(GtObject* obj) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_GUIDATAUI_H

--- a/src/intelli/gui/ui/logicnodeui.h
+++ b/src/intelli/gui/ui/logicnodeui.h
@@ -49,6 +49,8 @@ protected:
 
     QPainterPath computeShape() const override;
 
+    QRectF computeNodeHeaderRect() const override;
+
     QRectF computeNodeBodyRect() const override;
 
     QRectF computeBoundingRect() const override;
@@ -75,6 +77,12 @@ public:
                          PortType type,
                          PortIndex idx,
                          uint flags) const override;
+
+    void drawPort(QPainter& painter,
+                  PortInfo const& port,
+                  PortType type,
+                  PortIndex idx,
+                  uint flags) const override;
 };
 
 /**

--- a/src/intelli/gui/ui/logicnodeui.h
+++ b/src/intelli/gui/ui/logicnodeui.h
@@ -29,12 +29,6 @@ public:
 
     LogicNodeGeometry(NodeGraphicsObject const& object);
 
-    QRectF captionRect() const override;
-
-    QRect iconRect() const override;
-
-    QRectF evalStateRect() const override;
-
     QRectF portRect(PortType type, PortIndex idx) const override;
 
     QPainterPath beginCurve() const;
@@ -48,8 +42,6 @@ public:
 protected:
 
     QPainterPath computeShape() const override;
-
-    QRectF computeNodeHeaderRect() const override;
 
     QRectF computeNodeBodyRect() const override;
 

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -25,10 +25,12 @@
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/gui/ui/logicnodeui.h"
 #include "intelli/gui/ui/connectionui.h"
-#include "intelli/gui/ui/packageui.h"
 #include "intelli/gui/ui/graphcategoryui.h"
+#include "intelli/gui/ui/guidataui.h"
+#include "intelli/gui/ui/packageui.h"
 #include "intelli/gui/nodeui.h"
 #include "intelli/gui/grapheditor.h"
+#include "intelli/gui/guidata.h"
 #include "intelli/gui/property_item/stringselection.h"
 
 #include "intelli/calculators/graphexeccalculator.h"
@@ -261,6 +263,11 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(PackageUI));
     map.insert(GT_CLASSNAME(GraphCategory),
                GT_METADATA(GraphCategoryUI));
+
+    map.insert(GT_CLASSNAME(GuiData),
+               GT_METADATA(GuiDataUI));
+    map.insert(GT_CLASSNAME(LocalStateContainer),
+               GT_METADATA(GuiDataUI));
 
     map.insert(GT_CLASSNAME(LogicNode),
                GT_METADATA(LogicNodeUI));

--- a/tests/unittests/test_graph.cpp
+++ b/tests/unittests/test_graph.cpp
@@ -261,6 +261,18 @@ TEST(Graph, connection_model_custom_iterator)
                            reference.begin(), reference.end()));
 }
 
+TEST(Graph, connetion_model_reverse_iterator)
+{
+    QVector<int> data{1, 2, 3, 4, 5, 6};
+
+    // use a proxy to access `value` member of `MyStruct`
+    auto iter = makeReverseIter(data);
+
+    ASSERT_EQ(iter.size(), data.size());
+    EXPECT_TRUE(std::equal(iter.begin(), iter.end(),
+                           data.rbegin(), data.rend()));
+}
+
 TEST(Graph, predessecors_and_successors)
 {
     Graph graph;


### PR DESCRIPTION
Closes #282 - allowed nodes to be collapsed using the context menu

The collapsed state is stored in a data object per graph. The states are not merged when expanding a graph or grouping nodes.

### Before:

![grafik](https://github.com/user-attachments/assets/b4963504-1753-4380-b5b1-90da0acd4f76)

### After:

![grafik](https://github.com/user-attachments/assets/7abaf795-eabe-4e21-8054-4dc80a71317c)

