### PR TITLE
Fixed "ObjectUI Action 'Clear Graph' does not remove comments"

### DIFF
--- a/src/intelli/gui/commentgroup.cpp
+++ b/src/intelli/gui/commentgroup.cpp
@@ -74,6 +74,14 @@ CommentGroup::appendComment(std::unique_ptr<CommentData> comment)
 }
 
 void
+CommentGroup::clearComments()
+{
+    qDeleteAll(children());
+
+    assert(pimpl->comments.empty());
+}
+
+void
 CommentGroup::onObjectDataMerged()
 {
     GtObject::onObjectDataMerged();

--- a/src/intelli/gui/commentgroup.h
+++ b/src/intelli/gui/commentgroup.h
@@ -39,6 +39,11 @@ public:
 
     CommentData* appendComment(std::unique_ptr<CommentData> comment);
 
+    /**
+     * @brief Clears/Removes all comments
+     */
+    void clearComments();
+
 signals:
     
     void commentAppended(CommentData*);

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -897,9 +897,6 @@ GraphScene::selectAll()
 void
 GraphScene::keyPressEvent(QKeyEvent* event)
 {
-    // delete functionality should be handled by the view (i.e. `deleteSelectedObjects`)
-    assert(!gtApp->compareKeyEvent(event, gtApp->getShortCutSequence("delete")));
-
     // perform keyevent on node
     auto const& selected = Impl::findSelectedItems<NodeGraphicsObject*>(*this);
 

--- a/src/intelli/gui/nodeui.cpp
+++ b/src/intelli/gui/nodeui.cpp
@@ -18,7 +18,9 @@
 #include "intelli/node/groupoutputprovider.h"
 #include "intelli/graphexecmodel.h"
 #include "intelli/data/double.h"
+#include "intelli/gui/commentgroup.h"
 #include "intelli/gui/grapheditor.h"
+#include "intelli/gui/guidata.h"
 #include "intelli/gui/icons.h"
 #include "intelli/gui/nodeuidata.h"
 #include "intelli/gui/nodegeometry.h"
@@ -111,7 +113,7 @@ NodeUI::NodeUI(Option option) :
 
     addSeparator();
 
-    addSingleAction(tr("Clear Graph"), clearNodeGraph)
+    addSingleAction(tr("Clear Graph"), clearGraphNode)
         .setIcon(gt::gui::icon::clear())
         .setVisibilityMethod(toGraph);
 
@@ -459,7 +461,7 @@ NodeUI::deleteDynamicPort(Node* obj, PortType type, PortIndex idx)
 }
 
 void
-NodeUI::clearNodeGraph(GtObject* obj)
+NodeUI::clearGraphNode(GtObject* obj)
 {
     auto graph = toGraph(obj);
     if (!graph) return;
@@ -469,6 +471,11 @@ NodeUI::clearNodeGraph(GtObject* obj)
     Q_UNUSED(cmd);
     
     graph->clearGraph();
+
+    CommentGroup* commentGroup = GuiData::accessCommentGroup(*graph);
+    if (!commentGroup) return;
+
+    commentGroup->clearComments();
 }
 
 bool

--- a/src/intelli/gui/nodeui.h
+++ b/src/intelli/gui/nodeui.h
@@ -223,7 +223,7 @@ private:
      * @brief Clears the intelli graph (i.e. removes all nodes and connections)
      * @param obj Intelli graph to clear
      */
-    static void clearNodeGraph(GtObject* obj);
+    static void clearGraphNode(GtObject* obj);
 
     static bool deleteDummyNode(Node* node);
 


### PR DESCRIPTION
Closes #296 - Fixed 'clear graph' objectui action not clearing comments

Fixed assert firing erroneously in graph scene