### PR TITLE
Fixed: "Resizing a node/comment now creates an undo command"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Copying nodes will now always copy connections inbetween the selected nodes, regardless of
   whether the connections were selected or not.
 - `CTRL`-Clicking on a node that is already selected now unselects the node, thus making selections behave more intuitively. - #295
+- Resizing a node or comment now creates and undo command. - #290, #306
 - *Internal:* Moved utility functions from `intelli/globals.h` to `intelli/utilities.h`.
 - *Internal:* Implemented copy, move, and group functions in `intelli/graphutilities.h`.
 - *Internal:* Major refactoring of graph scene and related graphics objects.

--- a/src/intelli/gui/commentdata.cpp
+++ b/src/intelli/gui/commentdata.cpp
@@ -109,10 +109,24 @@ CommentData::CommentData(GtObject* parent) :
         emit commentCollapsedChanged(pimpl->collapsed.get());
     });
 
-    // position is changed in pairs -> sufficient to subscribe to changes
-    // to y-pos (avoids emitting singal twice)
+    // must subscribe to both properties incase only one changes
+    connect(&pimpl->posX, &GtAbstractProperty::changed, this, [this](){
+        emit commentPositionChanged();
+    });
     connect(&pimpl->posY, &GtAbstractProperty::changed, this, [this](){
         emit commentPositionChanged();
+    });
+
+    // must subscribe to both properties incase only one changes
+    connect(&pimpl->sizeWidth, &GtAbstractProperty::changed, this, [this](){
+        emit commentSizeChanged();
+    });
+    connect(&pimpl->sizeHeight, &GtAbstractProperty::changed, this, [this](){
+        emit commentSizeChanged();
+    });
+
+    connect(&pimpl->text, &GtAbstractProperty::changed, this, [this](){
+        emit commentChanged();
     });
 
     setObjectName(QStringLiteral("comment_%1")

--- a/src/intelli/gui/commentdata.h
+++ b/src/intelli/gui/commentdata.h
@@ -132,6 +132,12 @@ signals:
     /// Emitted once the position changes (is also triggered by `setPos`)
     void commentPositionChanged();
 
+    /// Emitted once the widget's size changes (is also triggered by `setSize`)
+    void commentSizeChanged();
+
+    /// Emitted once the comment's text changes
+    void commentChanged();
+
     /// Emitted once a new node connection was added
     void nodeConnectionAppended(NodeId nodeId);
 

--- a/src/intelli/gui/graphics/commentobject.h
+++ b/src/intelli/gui/graphics/commentobject.h
@@ -104,7 +104,7 @@ protected:
      * @brief Performs the resize action given the size difference.
      * @param diff Difference in size
      */
-    void resize(QSize diff) override;
+    void resizeBy(QSize diff) override;
 
 private:
 

--- a/src/intelli/gui/graphics/interactableobject.cpp
+++ b/src/intelli/gui/graphics/interactableobject.cpp
@@ -167,7 +167,7 @@ InteractableGraphicsObject::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
         m_translationStart.rx() = diff.x() - std::floor(diff.x());
         m_translationStart.ry() = diff.y() - std::floor(diff.y());
 
-        resize(QSize{(int)floor(diff.x()), (int)floor(diff.y())});
+        resizeBy(QSize{(int)floor(diff.x()), (int)floor(diff.y())});
 
         emit objectResized(this);
         break;

--- a/src/intelli/gui/graphics/interactableobject.h
+++ b/src/intelli/gui/graphics/interactableobject.h
@@ -134,7 +134,7 @@ protected:
      * @brief Performs the resize action given the size difference.
      * @param diff Difference in size
      */
-    virtual void resize(QSize diff) = 0;
+    virtual void resizeBy(QSize diff) = 0;
 
     void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
 
@@ -170,6 +170,10 @@ signals:
      */
     void objectCollapsed(InteractableGraphicsObject*, bool isCollapsed);
 
+    /**
+     * @brief Emitted once the object was resized, either programmatically or
+     * by the user. Should be called if "manually" resizing the object.
+     */
     void objectResized(InteractableGraphicsObject*);
 
     /**

--- a/src/intelli/gui/graphics/lineobject.cpp
+++ b/src/intelli/gui/graphics/lineobject.cpp
@@ -42,6 +42,8 @@ LineGraphicsObject::LineGraphicsObject(InteractableGraphicsObject const& start,
                 this, &LineGraphicsObject::updateEndPoint);
         connect(item, &QGraphicsObject::widthChanged,
                 this, &LineGraphicsObject::updateEndPoint);
+        connect(item, &QGraphicsObject::heightChanged,
+                this, &LineGraphicsObject::updateEndPoint);
         connect(item, &InteractableGraphicsObject::objectResized,
                 this, &LineGraphicsObject::updateEndPoints);
     }

--- a/src/intelli/gui/graphics/nodeobject.h
+++ b/src/intelli/gui/graphics/nodeobject.h
@@ -50,12 +50,12 @@ public:
 
     /**
      * @brief constructor
+     * @param scene
      * @param data Graph scene data which holds shared data for all node objects
-     * @param graph Graph to which the node belongs
      * @param node Node that this graphic object represents
      * @param ui Node UI used to access painter and geomtery data
      */
-    NodeGraphicsObject(GraphSceneData& data, Node& node, NodeUI& ui);
+    NodeGraphicsObject(QGraphicsScene& scene, GraphSceneData& data, Node& node, NodeUI& ui);
     ~NodeGraphicsObject();
 
     /**
@@ -256,7 +256,7 @@ protected:
      * @brief Performs the resize action given the size difference.
      * @param diff Difference in size
      */
-    void resize(QSize diff) override;
+    void resizeBy(QSize diff) override;
 
 signals:
 

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -1200,9 +1200,9 @@ GraphScene::onNodeAppended(Node* node)
     NodeUI* ui = qobject_cast<NodeUI*>(gtApp->defaultObjectUI(node));
     if (!ui) ui = &defaultUI;
 
-    auto entity = make_unique_qptr<NodeGraphicsObject, DirectDeleter>(*m_sceneData, *node, *ui);
-    // add to scene
-    addItem(entity);
+    auto entity = make_unique_qptr<NodeGraphicsObject, DirectDeleter>(
+        *this, *m_sceneData, *node, *ui
+    );
 
     // connect signals
     connect(entity, &NodeGraphicsObject::portContextMenuRequested,

--- a/src/intelli/node.cpp
+++ b/src/intelli/node.cpp
@@ -86,10 +86,20 @@ Node::Node(QString const& modelName, GtObject* parent) :
         if (pimpl->isActive) emit triggerNodeEvaluation();
     });
 
-    // position is changed in pairs -> sufficient to subscribe to changes
-    // to y-pos (avoids emitting singal twice)
+    // must subscribe to both properties incase only one changes
+    connect(&pimpl->posX, &GtAbstractProperty::changed, this, [this](){
+        emit nodePositionChanged();
+    });
     connect(&pimpl->posY, &GtAbstractProperty::changed, this, [this](){
         emit nodePositionChanged();
+    });
+
+    // must subscribe to both properties incase only one changes
+    connect(&pimpl->sizeWidth, &GtAbstractProperty::changed, this, [this](){
+        emit nodeSizeChanged();
+    });
+    connect(&pimpl->sizeHeight, &GtAbstractProperty::changed, this, [this](){
+        emit nodeSizeChanged();
     });
 
     connect(this, &Node::portConnected, this, [this](PortId portId){

--- a/src/intelli/node.h
+++ b/src/intelli/node.h
@@ -508,6 +508,12 @@ signals:
     void nodePositionChanged();
 
     /**
+     * @brief Emitted when the node has changed its size. Triggered by
+     * `setSize`.
+     */
+    void nodeSizeChanged();
+
+    /**
      * @brief Emitted just before the node is deleted similar to
      * QObject::destroyed with the difference that one may still access members
      */


### PR DESCRIPTION
Closes #290 - Resizing a node or comment now creates and undo command
Closes #306 - Changing a the text of comment also creates an undo command