### PR TITLE
Introduced a Scope Object for Evaluating Intelli Graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shortcut `CTRL+A` can now be used to select all objects in a scene - #292
 - A graph can now be duplicated within the explorer using its context menu or using the shortcut `CTRL+D`. - #291
 - Introduced so-called User Variables which behave like environment variables per graph hierarchy. These can be edited using the `Edit` menu in the graph view. - #294
+- *Internal:* Added support for scope object, that allows executing graphs with a custom source datatree. - #32
 
 ### Changed
 - Copying nodes will now always copy connections inbetween the selected nodes, regardless of
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a bug where small mouse movements would not cause the widget to resize. - #288
 - Fixed theme not updating Graph View, Scene, and Nodes correctly. - #301
+- *Internal:* `GraphBuilder` now also allows creating connections between ports with different but compatible type ids.
 
 ## [0.14.0] - 2025-04-04
 *This release is considered ABI compatible with `0.13.0`*

--- a/src/intelli/exec/detachedexecutor.cpp
+++ b/src/intelli/exec/detachedexecutor.cpp
@@ -294,6 +294,7 @@ DetachedExecutor::evaluateNode(Node& node)
 
     NodeUuid const& nodeUuid = node.uuid();
 
+    QPointer<GtObject> scope = model->scope();
     QPointer<GraphUserVariables const> userVariables = model->userVariables();
 
     auto run = [nodeUuid,
@@ -304,7 +305,8 @@ DetachedExecutor::evaluateNode(Node& node)
                 targetMetaObject = node.metaObject(),
                 targetObject = QPointer<Node>(&node),
                 executor = this,
-                userVariables
+                userVariables,
+                scope
                 ]() -> ReturnValue
     {
 #ifdef GT_INTELLI_DEBUG_NODE_EXEC
@@ -349,6 +351,7 @@ DetachedExecutor::evaluateNode(Node& node)
             // set data
             DummyNodeDataModel model{*node};
             model.setUserVariables(userVariables);
+            model.setScope(scope);
 
             bool success = true;
             success &= model.setNodeData(PortType::In,  inData);

--- a/src/intelli/exec/dummynodedatamodel.h
+++ b/src/intelli/exec/dummynodedatamodel.h
@@ -55,10 +55,15 @@ public:
 
     void setUserVariables(GraphUserVariables const* userVariables) { m_userVariables = userVariables; }
 
+    GtObject* scope() override { return m_scope; }
+
+    void setScope(GtObject* scope) { m_scope = scope; }
+
 private:
 
     Node* m_node = nullptr;
     data_model::DataItem m_data;
+    QPointer<GtObject> m_scope;
     QPointer<GraphUserVariables const> m_userVariables;
     bool m_success = true;
 };

--- a/src/intelli/graphbuilder.cpp
+++ b/src/intelli/graphbuilder.cpp
@@ -12,6 +12,7 @@
 #include "intelli/graph.h"
 #include "intelli/connection.h"
 #include "intelli/nodefactory.h"
+#include "intelli/nodedatafactory.h"
 
 #include <gt_utilities.h>
 
@@ -177,12 +178,12 @@ GraphBuilder::connect(Node& from, PortIndex outIdx, Node& to, PortIndex inIdx) n
     }
 
     // check if port type ids match
-    if (outPort->typeId != inPort->typeId)
+    if (!NodeDataFactory::instance().canConvert(outPort->typeId, inPort->typeId))
     {
         throw std::logic_error{
             buildError() +
-            ", port type ids mismatch! " +
-            gt::squoted(outPort->typeId.toStdString()) + " vs. " +
+            ", cannot convert port types! " +
+            gt::squoted(outPort->typeId.toStdString()) + " to " +
             gt::squoted(inPort->typeId.toStdString()) + " " +
             gt::brackets(pimpl->graph->caption().toStdString())
         };

--- a/src/intelli/graphexecmodel.cpp
+++ b/src/intelli/graphexecmodel.cpp
@@ -16,6 +16,7 @@
 
 #include <intelli/connection.h>
 
+#include <gt_project.h>
 #include <gt_eventloop.h>
 #include <gt_algorithms.h>
 
@@ -24,6 +25,8 @@ using namespace intelli;
 GraphExecutionModel::GraphExecutionModel(Graph& graph) :
     pimpl(std::make_unique<Impl>(graph))
 {
+    if (gtApp) pimpl->scope = gtApp->currentProject();
+
     if (graph.parentGraph())
     {
         gtError() << utils::logId(this->graph())
@@ -551,6 +554,18 @@ GraphExecutionModel::userVariables() const
     assert(root);
 
     return root->findDirectChild<GraphUserVariables const*>();
+}
+
+GtObject*
+GraphExecutionModel::scope()
+{
+    return pimpl->scope;
+}
+
+void
+GraphExecutionModel::setScope(GtObject* scope)
+{
+    pimpl->scope = scope;
 }
 
 void

--- a/src/intelli/graphexecmodel.h
+++ b/src/intelli/graphexecmodel.h
@@ -278,6 +278,10 @@ public:
     GT_NO_DISCARD Q_INVOKABLE
     GraphUserVariables const* userVariables() const override;
 
+    GtObject* scope() override;
+
+    void setScope(GtObject* scope);
+
 protected:
 
     /**

--- a/src/intelli/graphexecmodel.h
+++ b/src/intelli/graphexecmodel.h
@@ -275,11 +275,26 @@ public:
     GT_NO_DISCARD
     inline GraphDataModel const& data() const;
 
-    GT_NO_DISCARD Q_INVOKABLE
+    /**
+     * @brief Returns the user variables object if any exists.
+     * @return User variables object (may be null)
+     */
+    GT_NO_DISCARD
     GraphUserVariables const* userVariables() const override;
 
+    /**
+     * @brief Returns the scope object used for evalauation. The scope object
+     * is intended to to be used for interfacing with the datamodel.
+     * By default the scope object s the current project, but it may be set to
+     * a sub datatree or an external tree instead.
+     * @return Scope object (may be null).
+     */
     GtObject* scope() override;
 
+    /**
+     * @brief Sets the scope object that should be used for evalauation.
+     * @param Scope object
+     */
     void setScope(GtObject* scope);
 
 protected:

--- a/src/intelli/gui/grapheditor.cpp
+++ b/src/intelli/gui/grapheditor.cpp
@@ -22,6 +22,7 @@
 #include <gt_logging.h>
 
 #include <gt_application.h>
+#include <gt_project.h>
 #include <gt_icons.h>
 
 #include <QVBoxLayout>
@@ -86,6 +87,7 @@ GraphEditor::setData(GtObject* obj)
                    .arg(relativeNodePath(*graph));
         return;
     }
+    model->setScope(gtApp->currentProject());
     model->reset();
 
     // setup state manager

--- a/src/intelli/node/genericcalculatorexec.cpp
+++ b/src/intelli/node/genericcalculatorexec.cpp
@@ -14,6 +14,7 @@
 #include <intelli/data/bool.h>
 #include <intelli/data/string.h>
 #include <intelli/data/integer.h>
+#include <intelli/nodedatainterface.h>
 
 #include "gt_algorithms.h"
 #include "gt_coreapplication.h"
@@ -323,7 +324,11 @@ GenericCalculatorExecNode::GenericCalculatorExecNode() :
 
         lay->addWidget(edit);
 
-        auto* view = new GtPropertyTreeView(gtApp->currentProject());
+        auto* model = exec::nodeDataInterface(*this);
+        GtObject* scope = model ? model->scope() : gtApp->currentProject();
+        assert(scope);
+
+        auto* view = new GtPropertyTreeView(scope);
         view->setAnimated(false);
         lay->addWidget(view);
 

--- a/src/intelli/nodedatainterface.h
+++ b/src/intelli/nodedatainterface.h
@@ -15,16 +15,18 @@
 
 #include <gt_finally.h>
 
+class GtObject;
+
 namespace intelli
 {
 
 using NodeDataPtrList = std::vector<std::pair<PortId, NodeDataPtr>>;
 
+class GraphUserVariables;
 /**
  * @brief The NodeDataInterface class.
  * Interface to access and set the data of a node port
  */
-class GraphUserVariables;
 class NodeDataInterface : public QObject
 {
     Q_OBJECT
@@ -47,7 +49,20 @@ public:
      */
     virtual void setNodeEvaluationFailed(NodeUuid const& nodeUuid) {}
 
+    /**
+     * @brief Returns the user variables object if any exists.
+     * @return User variables object (may be null)
+     */
     virtual GraphUserVariables const* userVariables() const { return nullptr; }
+
+    /**
+     * @brief Returns the scope object used for evalauation. The scope object
+     * is intended to to be used for interfacing with the datamodel.
+     * By default the scope object s the current project, but it may be set to
+     * a sub datatree or an external tree instead.
+     * @return Scope object (may be null).
+     */
+    virtual GtObject* scope() { return nullptr; }
 
     /// Helper struct to scope the duration of a node evaluation
     struct NodeEvaluationEndedFunctor

--- a/src/intelli/private/graphexecmodel_impl.h
+++ b/src/intelli/private/graphexecmodel_impl.h
@@ -105,6 +105,8 @@ struct GraphExecutionModel::Impl
 
     /// assoicated graph
     QPointer<Graph> graph;
+    /// scope object
+    QPointer<GtObject> scope;
     /// data model for all nodes and their ports
     GraphDataModel data;
     /// nodes that should be evaluated


### PR DESCRIPTION
Closes #32 - introduced a scope object for evaluating intelli graphs
Closes #256 - use scope object for accessing linked objects

Scope is accessible using `exec::nodeDataInterface(*this)->svope()`. Note: `exec::nodeDataInterface` may yield null.