### PR TITLE
Dynamic Node: Add option to allow adding ports only programmatically

### DIFF
--- a/src/intelli/dynamicnode.h
+++ b/src/intelli/dynamicnode.h
@@ -30,26 +30,36 @@ public:
 
     ~DynamicNode();
 
-    /// Option for the node creation
-    enum Option
+    /// Option for the node creation.
+    enum Option : size_t
     {
+        /// no ports can be added dynamically. Ports are not saved persistently.
+        NoDynamicPorts = 0,
+        /// input ports may be added dynamically (output ports may still be
+        /// added, but wont be saved persistently)
+        DynamicInput = 1 << 0,
+        DynamicInputOnly [[deprecated("Use `DynamicOutput` instead")]] = 1 << 2,
+        /// output ports may be added dynamically
+        DynamicOutput = 1 << 1,
+        DynamicOutputOnly [[deprecated("Use `DynamicOutput` instead")]] = 1 << 2,
         /// both inputs and ouput ports can be added dynamically
-        DynamicInputAndOutput = 0,
-        /// only input ports may be added dynamically (output ports may still be
-        /// added, but wont be saved persistently)
-        DynamicInputOnly,
-        /// only output ports may be added dynamically (input ports may still be
-        /// added, but wont be saved persistently)
-        DynamicOutputOnly,
-        /// no ports can be added dynamically
-        NoDynamicPorts
+        DynamicInputAndOutput = DynamicInput | DynamicOutput,
+        /// input ports can only be added programmatically
+        /// (no UI action for adding/deleting port is added by default)
+        NoUserDynamicInput  = 1 << 2,
+        /// output ports can only be added programmatically
+        /// (no UI action for adding/deleting port is added by default)
+        NoUserDynamicOutput = 1 << 3,
+        /// input and output ports may only be added programmatically
+        /// (no UI action for adding/deleting port is added by default)
+        NoUserDynamicInputAndOutput = NoUserDynamicInput | NoUserDynamicOutput
     };
 
     /**
      * @brief Getter for the node option used
      * @return
      */
-    Option dynamicNodeOption() const;
+    size_t dynamicNodeOption() const;
 
     /**
      * @brief Retruns true if a port is considered dynamic (i.e. was added at
@@ -118,13 +128,13 @@ protected:
      * @param parent Parent object
      */
     DynamicNode(QString const& modelName,
-                Option option = {},
+                size_t option = DynamicInputAndOutput,
                 GtObject* parent = nullptr);
 
     DynamicNode(QString const& modelName,
                 QStringList inputWhiteList,
                 QStringList outputWhiteList,
-                Option option = {},
+                size_t option = DynamicInputAndOutput,
                 GtObject* parent = nullptr);
 
     /**

--- a/src/intelli/graph.cpp
+++ b/src/intelli/graph.cpp
@@ -52,16 +52,6 @@ Graph::Graph() :
 Graph::~Graph()
 {
     emit graphAboutToBeDeleted(QPrivateSignal());
-
-    Modification cmd = modify();
-    Q_UNUSED(cmd);
-
-    // remove connections
-    auto& conGroup = this->connectionGroup();
-    delete& conGroup;
-
-    auto const& nodes = this->nodes();
-    qDeleteAll(nodes);
 }
 
 Graph*

--- a/src/intelli/graphuservariables.cpp
+++ b/src/intelli/graphuservariables.cpp
@@ -39,7 +39,7 @@ GraphUserVariables::GraphUserVariables(GtObject* parent) :
 
     setFlag(UserRenamable, false);
     setFlag(UserDeletable, false);
-    setUserHidden(!(gtApp && gtApp->devMode()));
+    setFlag(UserHidden, true);
 
     GtPropertyStructDefinition def{S_TYPE};
     def.defineMember(S_MEMBER, gt::makeVariantProperty());

--- a/src/intelli/gui/nodeui.cpp
+++ b/src/intelli/gui/nodeui.cpp
@@ -43,6 +43,7 @@
 using namespace intelli;
 
 using BoolObjectMethod = std::function<bool (GtObject*)>;
+using BoolPortMethod = std::function<bool (Node*, PortType, PortIndex)>;
 
 using DeleteAction = std::pair<NodeUI::CustomDeleteFunctor,
                                NodeUI::EnableCustomDeleteFunctor>;
@@ -55,12 +56,21 @@ inline BoolObjectMethod NOT(Functor fA)
         return !a(obj);
     };
 }
+
+
 /// AND operator
 template <typename Functor>
 inline BoolObjectMethod operator*(BoolObjectMethod fA, Functor fOther)
 {
     return [a = std::move(fA), b = std::move(fOther)](GtObject* obj){
         return a(obj) && b(obj);
+    };
+}
+template <typename Functor>
+inline BoolPortMethod operator*(BoolPortMethod fA, Functor fOther)
+{
+    return [a = std::move(fA), b = std::move(fOther)](Node* obj, PortType type, PortIndex idx){
+        return a(obj, type, idx) && b(obj, type, idx);
     };
 }
 
@@ -131,13 +141,11 @@ NodeUI::NodeUI(Option option) :
 
     if (!(option & NoDefaultPortActions))
     {
-        auto const hasOutputPorts = [](GtObject* obj){
-            return !(static_cast<DynamicNode*>(obj)->dynamicNodeOption() &
-                     DynamicNode::DynamicInputOnly);
+        auto const hasInputPorts = [](GtObject* obj, auto ...){
+            return  (static_cast<DynamicNode*>(obj)->dynamicNodeOption() & DynamicNode::DynamicInput);
         };
-        auto const hasInputPorts = [](GtObject* obj){
-            return !(static_cast<DynamicNode*>(obj)->dynamicNodeOption() &
-                     DynamicNode::DynamicOutputOnly);
+        auto const hasOutputPorts = [](GtObject* obj, auto ...){
+            return  (static_cast<DynamicNode*>(obj)->dynamicNodeOption() & DynamicNode::DynamicOutput);
         };
 
         addSingleAction(tr("Add In Port"), addInPort)
@@ -152,8 +160,13 @@ NodeUI::NodeUI(Option option) :
 
         addPortAction(tr("Delete Port"), deleteDynamicPort)
             .setIcon(gt::gui::icon::delete_())
-            .setVerificationMethod(isDynamicPort)
-            .setVisibilityMethod(isDynamicNode);
+            .setVerificationMethod(BoolPortMethod{isDynamicPort} * isInputPort * hasInputPorts)
+            .setVisibilityMethod(isDynamicNode * hasInputPorts);
+
+        addPortAction(tr("Delete Port"), deleteDynamicPort)
+            .setIcon(gt::gui::icon::delete_())
+            .setVerificationMethod(BoolPortMethod{isDynamicPort} * isOutputPort * hasOutputPorts)
+            .setVisibilityMethod(isDynamicNode * hasOutputPorts);
     }
 
     if (gtApp && gtApp->devMode())
@@ -367,7 +380,19 @@ NodeUI::isRootGraph(GtObject const* obj)
 }
 
 bool
-NodeUI::isDynamicPort(GtObject* obj, PortType type, PortIndex idx)
+NodeUI::isInputPort(Node* node, PortType type, PortIndex index)
+{
+    return node && type == PortType::In && node->ports(type).size() > index;
+}
+
+bool
+NodeUI::isOutputPort(Node* node, PortType type, PortIndex index)
+{
+    return node && type == PortType::Out && node->ports(type).size() > index;
+}
+
+bool
+NodeUI::isDynamicPort(Node* obj, PortType type, PortIndex idx)
 {
     if (toDummy(obj)) return false;
     if (auto* node = toDynamicNode(obj))
@@ -378,7 +403,7 @@ NodeUI::isDynamicPort(GtObject* obj, PortType type, PortIndex idx)
 }
 
 bool
-NodeUI::isDynamicNode(GtObject* obj, PortType, PortIndex)
+NodeUI::isDynamicNode(Node* obj, PortType, PortIndex)
 {
     return toDynamicNode(obj);
 }

--- a/src/intelli/gui/nodeui.h
+++ b/src/intelli/gui/nodeui.h
@@ -170,14 +170,17 @@ public:
      */
     static void deleteDynamicPort(Node* obj, PortType type, PortIndex idx);
 
+    static bool isInputPort(Node* obj, PortType type, PortIndex idx);
+    static bool isOutputPort(Node* obj, PortType type, PortIndex idx);
+
     /**
-     * @brief Similar to `toDynamicNode`. Can be used for validation of a port
-     * action
+     * @brief Similar to `toDynamicNode`. Can be used for validating port
+     * actions
      * @param obj Object to cast
      * @return node object (may be null)
      */
-    static bool isDynamicPort(GtObject* obj, PortType type, PortIndex idx);
-    static bool isDynamicNode(GtObject* obj, PortType, PortIndex);
+    static bool isDynamicPort(Node* obj, PortType type, PortIndex idx);
+    static bool isDynamicNode(Node* obj, PortType type, PortIndex idx);
 
     /**
      * @brief Returns the list of all port actions registered

--- a/src/intelli/node/abstractgroupprovider.h
+++ b/src/intelli/node/abstractgroupprovider.h
@@ -33,8 +33,7 @@ public:
                           QStringList iwl = {},
                           QStringList owl = {}) :
         DynamicNode(modelName, std::move(iwl), std::move(owl),
-                    providerType == PortType::In ? DynamicOutputOnly :
-                                                   DynamicInputOnly)
+                    providerType == PortType::In ? DynamicOutput : DynamicInput)
     {
         setFlag(UserDeletable, false);
         setNodeFlag(Unique, true);

--- a/src/intelli/node/binarydisplay.cpp
+++ b/src/intelli/node/binarydisplay.cpp
@@ -24,7 +24,7 @@ BinaryDisplayNode::BinaryDisplayNode() :
     DynamicNode(tr("Binary Display"),
                 QStringList{typeId<BoolData>()},
                 QStringList{},
-                DynamicNode::DynamicInputOnly)
+                DynamicNode::DynamicInput)
 {
     setNodeEvalMode(NodeEvalMode::Blocking);
     setNodeFlag(Resizable);

--- a/src/intelli/node/dummy.cpp
+++ b/src/intelli/node/dummy.cpp
@@ -17,7 +17,8 @@ using namespace intelli;
 DummyNode::DummyNode() :
     DynamicNode("Dummy Node",
                 QStringList{typeId<InvalidData>()},
-                QStringList{typeId<InvalidData>()}),
+                QStringList{typeId<InvalidData>()},
+                NoUserDynamicInputAndOutput),
     m_object("target", tr("Target"), tr("Target Object"), this, QStringList{})
 {
     setFlag(UserRenamable, false);

--- a/src/intelli/node/input/graphuservariablesinput.cpp
+++ b/src/intelli/node/input/graphuservariablesinput.cpp
@@ -57,7 +57,7 @@ NodeDataPtr variantToNodeData(QVariant value)
 } // namespace
 
 GraphUserVariablesInputNode::GraphUserVariablesInputNode() :
-    DynamicNode("User Variables", DynamicOutputOnly)
+    DynamicNode("Constants", NoUserDynamicOutput)
 {
     setNodeEvalMode(NodeEvalMode::Blocking);
 }


### PR DESCRIPTION
Refactored `DynamicNode::Option` to support configurations, where dynamic port should only be added/removed programmatically and not by the user