### PR TITLE
Fix undo/redo actions for graph user variables and the corresponding input node

### DIFF
--- a/src/intelli/dynamicnode.h
+++ b/src/intelli/dynamicnode.h
@@ -186,6 +186,12 @@ private slots:
     void onPortDeleted(PortType type, PortIndex idx);
 
     /**
+     * @brief Updates the property container entry for the changed port
+     * @param portId
+     */
+    void onPortChanged(PortId portId);
+
+    /**
      * @brief Inserts the port described by the property container entry to
      * the node
      * @param idx

--- a/src/intelli/graph.h
+++ b/src/intelli/graph.h
@@ -210,7 +210,8 @@ public:
     QVector<NodeId> nodeIds() const;
     
     /**
-     * @brief Returns a list of all connections in this graph
+     * @brief Returns a list of all connections in this graph. Prefer
+     * `connectionModel().iterateConnections()`.
      * @return Connections
      */
     QList<Connection*> connections();
@@ -220,7 +221,7 @@ public:
      * @brief Returns a list of all connection ids in this graph
      * @return Connection ids
      */
-    [[deprecated]]
+    [[deprecated("Use `connectionModel().iterateConnections()` instead.")]]
     QVector<ConnectionId> connectionIds() const;
     
     /**
@@ -235,7 +236,7 @@ public:
     Node const* findNodeByUuid(NodeUuid const& uuid) const;
 
     /**
-     * @brief Attempts to finde a connection specified by the given connectionId
+     * @brief Attempts to find a connection specified by the given connectionId
      * @param conId Connection id
      * @return connection matched by conId (null if connection was not found)
      */
@@ -356,6 +357,8 @@ public:
      * @param conId Connection to chech
      * @return Can connect
      */
+    bool canAppendConnection(ConnectionId conId);
+    [[deprecated("Use `canAppendConnection` instead")]]
     bool canAppendConnections(ConnectionId conId);
 
     /**
@@ -588,7 +591,7 @@ signals:
      * @brief Emitted once a connection was appended
      * @param Pointer to connection object
      */
-    void connectionAppended(Connection* connection);
+    void connectionAppended(ConnectionId connectionId);
     void globalConnectionAppended(ConnectionUuid connectionUuid);
 
     /**

--- a/src/intelli/graphbuilder.cpp
+++ b/src/intelli/graphbuilder.cpp
@@ -189,15 +189,13 @@ GraphBuilder::connect(Node& from, PortIndex outIdx, Node& to, PortIndex inIdx) n
         };
     }
 
-    auto connection = std::make_unique<Connection>();
-    connection->setOutNodeId(from.id());
-    connection->setOutPort(from.portId(PortType::Out, outIdx));
-    connection->setInNodeId(to.id());
-    connection->setInPort(to.portId(PortType::In, inIdx));
+    ConnectionId conId{};
+    conId.outNodeId = from.id();
+    conId.outPort = from.portId(PortType::Out, outIdx);
+    conId.inNodeId = to.id();
+    conId.inPort = to.portId(PortType::In, inIdx);
 
-    auto conId = connection->connectionId();
-
-    if (!pimpl->graph->appendConnection(std::move(connection)))
+    if (!pimpl->graph->appendConnection(conId))
     {
         throw std::logic_error{
             buildError() +

--- a/src/intelli/graphuservariables.h
+++ b/src/intelli/graphuservariables.h
@@ -11,6 +11,7 @@
 #define GT_INTELLI_GRAPHUSERVARIABLES_H
 
 #include "intelli/exports.h"
+#include "intelli/globals.h"
 
 #include <gt_platform.h>
 #include <gt_object.h>
@@ -31,6 +32,8 @@ class GT_INTELLI_EXPORT GraphUserVariables : public GtObject
     Q_OBJECT
 
 public:
+
+    using ID = typename PortId::value_type;
 
     Q_INVOKABLE
     GraphUserVariables(GtObject* parent = nullptr);
@@ -74,6 +77,20 @@ public:
     QVariant value(QString const& key) const;
 
     /**
+     * @brief Returns an id for the given key that is unique amongst all of its
+     * entries. This id is mostely intended for nodes that need a somewaht
+     * unqiue, numerical value for identifying keys.
+     *
+     * Note: When deleting an entry and adding a new entry, the ID of these
+     * entries may be the same, however all active entries are guranteed to have
+     * different ids.
+     * @param key Key
+     * @return ID. Invalid ids are zeroed.
+     */
+    GT_NO_DISCARD
+    ID id(QString const& key) const;
+
+    /**
      * @brief Returns all keys of the entries as a stringlist.
      * @return Keys
      */
@@ -108,6 +125,10 @@ public:
      * @param other Other
      */
     void mergeWith(GraphUserVariables& other);
+
+protected:
+
+    void onObjectDataMerged() override;
 
 signals:
 

--- a/src/intelli/gui/graphics/connectionobject.h
+++ b/src/intelli/gui/graphics/connectionobject.h
@@ -11,13 +11,13 @@
 #define GT_INTELLI_CONNECTIONGRAPHICSOBJECT_H
 
 #include <intelli/memory.h>
-#include <intelli/connection.h>
 #include <intelli/gui/connectiongeometry.h>
 #include <intelli/gui/graphics/graphicsobject.h>
 
 namespace intelli
 {
 
+class Graph;
 class NodeGraphicsObject;
 
 /**
@@ -39,7 +39,8 @@ public:
 
     static std::unique_ptr<ConnectionGraphicsObject>
     makeConnection(QGraphicsScene& scene,
-                   Connection& object,
+                   Graph& graph,
+                   ConnectionId conId,
                    NodeGraphicsObject const& outNodeObj,
                    NodeGraphicsObject const& inNodeObj);
 
@@ -59,14 +60,6 @@ public:
      * @return Is a draft connection.
      */
     bool isDraft() const;
-
-    /**
-     * @brief Returns the associated connection object. May be null if the
-     * connection is a draft connection. Prefer to use `connectionId`.
-     * @return Connection object.
-     */
-    Connection* connection();
-    Connection const* connection() const;
 
     /**
      * @brief Bounding rect of this object
@@ -148,8 +141,8 @@ protected:
 
 private:
 
-    /// Pointer to connection object
-    QPointer<Connection> m_object;
+    /// Pointer to graph object
+    QPointer<Graph> m_graph;
     /// pointers to outNode and inNode i.e. the start and end node
     QPointer<NodeGraphicsObject const> m_outNode, m_inNode;
     /// Connection id
@@ -170,15 +163,14 @@ private:
      * `outNodeObj` or `inNodeObj` must be not null, else both objects must
      * not be null.
      * @param scene Scene this object will be added to
-     * @param object Connection object this object refers to. May be invalid
-     * if the connection is a draft.
+     * @param graph Graph object. May be invalid if the connection is a draft.
      * @param connection ConnectionId to render. May be partially invalid,
      * indicating a draft connection.
      * @param outNodeObj graphics object for the output side
      * @param inNodeObj graphics object for the output side
      */
     explicit ConnectionGraphicsObject(QGraphicsScene& scene,
-                                      Connection* object,
+                                      Graph* graph,
                                       ConnectionId connection,
                                       NodeGraphicsObject const* outNodeObj = {},
                                       NodeGraphicsObject const* inNodeObj = {});

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -461,10 +461,10 @@ GraphScene::GraphScene(Graph& graph) :
     {
         onNodeAppended(node);
     }
-    auto const& connections = m_graph->connections();
-    for (auto* con : connections)
+    auto const& connections = m_graph->connectionModel().iterateConnections();
+    for (ConnectionId conId : connections)
     {
-        onConnectionAppended(con);
+        onConnectionAppended(conId);
     }
 
     // comments
@@ -1265,11 +1265,9 @@ GraphScene::onNodeDoubleClicked(NodeGraphicsObject* sender)
 }
 
 void
-GraphScene::onConnectionAppended(Connection* con)
+GraphScene::onConnectionAppended(ConnectionId conId)
 {
-    assert(con);
-
-    auto conId = con->connectionId();
+    assert(conId.isValid());
 
     // access nodes and ports
     auto* inNode  = nodeObject(conId.inNodeId);
@@ -1279,7 +1277,7 @@ GraphScene::onConnectionAppended(Connection* con)
     assert(outNode);
 
     auto entity = convert_to_unique_qptr<DirectDeleter>(
-        ConnectionGraphicsObject::makeConnection(*this, *con, *outNode, *inNode)
+        ConnectionGraphicsObject::makeConnection(*this, graph(), conId, *outNode, *inNode)
     );
     entity->setConnectionShape(m_connectionShape);
 
@@ -1344,12 +1342,12 @@ GraphScene::onFinalizeDraftConnection(ConnectionId conId)
 {
     Impl::clearHighlights(*this);
 
-    if (conId.isDraft() || !graph().canAppendConnections(conId)) return;
+    if (conId.isDraft() || !graph().canAppendConnection(conId)) return;
 
     auto cmd = gtApp->makeCommand(&graph(), tr("Append %1").arg(toString(conId)));
     Q_UNUSED(cmd);
 
-    graph().appendConnection(std::make_unique<Connection>(conId));
+    graph().appendConnection(conId);
 }
 
 void

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -202,7 +202,7 @@ private slots:
 
     void onNodeDoubleClicked(NodeGraphicsObject* sender);
 
-    void onConnectionAppended(Connection* con);
+    void onConnectionAppended(ConnectionId conId);
 
     void onConnectionDeleted(ConnectionId conId);
 

--- a/src/intelli/gui/nodeui.cpp
+++ b/src/intelli/gui/nodeui.cpp
@@ -533,7 +533,7 @@ NodeUI::deleteDynamicPort(Node* obj, PortType type, PortIndex idx)
     Node::PortInfo* port = node->port(portId);
     assert(port);
 
-    auto cmd = gtApp->makeCommand(graph,
+    auto cmd = gtApp->makeCommand(graph->rootGraph(),
                                   QStringLiteral("Deleting port '%1' of node '%2'")
                                       .arg(toString(*port), relativeNodePath(*node)));
     Q_UNUSED(cmd);

--- a/tests/unittests/test_graph.cpp
+++ b/tests/unittests/test_graph.cpp
@@ -231,6 +231,25 @@ TEST(Graph, connection_model_iterate_over_connected_nodes_by_port)
     EXPECT_EQ(std::distance(riPort.begin(), riPort.end()), 2);
 }
 
+TEST(Graph, connection_model_iterate_over_all_connections)
+{
+    Graph graph;
+
+    auto& conModel = graph.connectionModel();
+
+    EXPECT_EQ(conModel.iterateConnections().size(), 0);
+    EXPECT_EQ(graph.connections().size(), 0);
+
+    test::buildLinearGraph(graph);
+
+    EXPECT_EQ(conModel.iterateConnections().size(), graph.connections().size());
+
+    graph.deleteConnection(*conModel.iterateConnections().begin());
+
+    EXPECT_EQ(conModel.iterateConnections().size(), graph.connections().size());
+}
+
+
 struct IntProxy
 {
     using value_type = int;


### PR DESCRIPTION
### Fixed

- Fixed undo/redo for the graph variables input node (user constants) - Closes #314

- Fixed Dynamic Nodes not updating the memento when a port is changed (e.g. because the Type ID is changed) 

However, I still could not fix restoring connection with an undo/redo when deleting dynamic ports... (see #316)

### Refactoring

I also refactored the `Graph` class and its signal such that `ConnectionId` is preferred over `Connection*`. This is an **API change**, however I am willing to introduce the change now with all other ABI and potential API changes. I am confident that the changed API is not used outside this module since `Connection` is not exported (well it is, but only for tests). 

My thinking process was, that the `GraphConnectionModel` contains all valid connections inbetween nodes and that the datamodel objects (type `Connection`) are redundant (at least to the user of the library). I added a function to the connection model that allows to iterate over all `ConnectioId`s of the connection model. As far as I can this approach also does not allocate memory on the heap just to iterate over the connections - which is a plus in my book. 