### PR TITLE
Resolve: "Cut and Paste Nodes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Selected nodes can now be "cut" using the corresponding shortcut (`Ctrl+X`). Cut nodes are "greyed-out", similar to how cutting works for files and folders. Once the selection is pasted the cut-objects are deleted. - #283
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Selected nodes can now be "cut" using the corresponding shortcut (`Ctrl+X`). Cut nodes are "greyed-out", similar to how cutting works for files and folders. Once the selection is pasted the cut-objects are deleted. - #283
+- Selected nodes can now be "cut" using the corresponding shortcut (usually `Ctrl+X`). Cut-nodes are "greyed-out", similar to how cutting works for files and folders. Once the selection is pasted, the cut-objects are deleted. - #283
 
 ### Changed
 

--- a/src/intelli/graph.cpp
+++ b/src/intelli/graph.cpp
@@ -376,6 +376,9 @@ Graph::graphNodes() const
 void
 Graph::clearGraph()
 {
+    auto* guiData = findDirectChild<GuiData*>();
+    if (guiData) guiData->clearData();
+
     // connections should be removed automatically
     qDeleteAll(nodes());
 }

--- a/src/intelli/gui/graphics/connectionobject.cpp
+++ b/src/intelli/gui/graphics/connectionobject.cpp
@@ -89,6 +89,7 @@ ConnectionGraphicsObject::ConnectionGraphicsObject(QGraphicsScene& scene,
         connect(nodeObj, &NodeGraphicsObject::xChanged, this, updateEndPoint);
         connect(nodeObj, &NodeGraphicsObject::yChanged, this, updateEndPoint);
         connect(nodeObj, &NodeGraphicsObject::nodeGeometryChanged, this, updateEndPoint);
+        connect(nodeObj, &NodeGraphicsObject::opacityChanged, this, [this](){ update(); });
         updateEndPoint();
     }
 }
@@ -255,10 +256,15 @@ ConnectionGraphicsObject::paint(QPainter* painter,
         flags
     );
 
-    if (isDraft)
+    if (draftType == PortType::In  || m_outNode->opacity() < 1)
     {
         double const portRadius = style.node.portRadius;
-        p.drawEndPoint(*painter, path, portRadius, invert(draftType));
+        p.drawEndPoint(*painter, path, portRadius, PortType::Out);
+    }
+    if (draftType == PortType::Out || m_inNode->opacity() < 1)
+    {
+        double const portRadius = style.node.portRadius;
+        p.drawEndPoint(*painter, path, portRadius, PortType::In);
     }
 
 #ifdef GT_INTELLI_DEBUG_CONNECTION_GRAPHICS

--- a/src/intelli/gui/graphics/nodeobject.cpp
+++ b/src/intelli/gui/graphics/nodeobject.cpp
@@ -136,7 +136,7 @@ NodeGraphicsObject::NodeGraphicsObject(QGraphicsScene& scene,
 
     updateChildItems();
 
-    setupDropShadowEffect(
+    auto* shadow = setupDropShadowEffect(
         [this](){
             return boundingRect();
         },
@@ -147,6 +147,10 @@ NodeGraphicsObject::NodeGraphicsObject(QGraphicsScene& scene,
                                            NodePainter::DrawNodeBackground);
         }
     );
+
+    connect(this, &QGraphicsObject::opacityChanged, shadow, [this, shadow](){
+        shadow->setVisible(!(opacity() < 1.0));
+    });
 }
 
 NodeGraphicsObject::~NodeGraphicsObject() = default;

--- a/src/intelli/gui/graphics/popupitem.cpp
+++ b/src/intelli/gui/graphics/popupitem.cpp
@@ -70,7 +70,6 @@ PopupItem::PopupItem(QGraphicsScene& scene, QString const& text, seconds timeout
 
 PopupItem::~PopupItem()
 {
-    gtDebug() << "REMOVED" << this;
     s_activeItems.removeOne(this);
 }
 

--- a/src/intelli/gui/graphics/popupitem.cpp
+++ b/src/intelli/gui/graphics/popupitem.cpp
@@ -70,14 +70,21 @@ PopupItem::PopupItem(QGraphicsScene& scene, QString const& text, seconds timeout
 
 PopupItem::~PopupItem()
 {
+    gtDebug() << "REMOVED" << this;
     s_activeItems.removeOne(this);
+}
+
+PopupItem*
+PopupItem::addPopupItem(QGraphicsScene& scene, QString const& text, seconds timeout)
+{
+    return new PopupItem(scene, text, timeout);
 }
 
 void
 PopupItem::clearActivePopups()
 {
     // reverse iterate to not cause access to dangling iterator
-    for (auto i : s_activeItems)
+    for (auto i : qAsConst(s_activeItems))
     {
         i->hide();
     }

--- a/src/intelli/gui/graphics/popupitem.h
+++ b/src/intelli/gui/graphics/popupitem.h
@@ -30,17 +30,13 @@ public:
 
     using seconds = std::chrono::seconds;
 
-    PopupItem(QGraphicsScene& scene, QString const& text, seconds timeout);
-    ~PopupItem();
-
     static PopupItem* addPopupItem(QGraphicsScene& scene,
                                    QString const& text,
-                                   seconds timeout)
-    {
-        return new PopupItem(scene, std::move(text), timeout);
-    }
+                                   seconds timeout);
 
     static void clearActivePopups();
+
+    ~PopupItem();
 
     /**
      * @brief Bounding rect of this object
@@ -55,6 +51,8 @@ protected:
                QWidget* widget = nullptr) override;
 
 private:
+
+    PopupItem(QGraphicsScene& scene, QString const& text, seconds timeout);
 
     /// Timeline for anmation
     QTimeLine m_timeLine;

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -91,6 +91,8 @@ public slots:
      */
     void alignObjectsToGrid();
 
+    void resetSelection();
+
     /**
      * @brief Attempts to delete all selected object. If no objects are
      * selected, no objects will be deleted. Creates an undo-redo command.
@@ -134,6 +136,9 @@ signals:
     void objectAdded(InteractableGraphicsObject* object, QPrivateSignal);
 
 protected:
+
+    /// prefer `resetSelection`
+    using GtGraphicsScene::clearSelection;
 
     void keyPressEvent(QKeyEvent* event) override;
 

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -91,6 +91,9 @@ public slots:
      */
     void alignObjectsToGrid();
 
+    /**
+     * @brief Clears the selection.
+     */
     void resetSelection();
 
     /**
@@ -108,10 +111,17 @@ public slots:
     /**
      * @brief Copies the selection to the clipboard. If no objects are selected,
      * no action is performed.
+     * @return Whether selected objects were copied
      */
     bool copySelectedObjects();
 
-    /// TODO
+    /**
+     * @brief Starts a cutting operation. Cut-objects are made translucent to
+     * emphasize that these objects are being cut. Another call to
+     * `pasteObjects` is necessary to finalize the cut-operation. Performing
+     * other actions aborts the cut-operation.
+     * @return Whether selected objects were cut (began being cut)
+     */
     bool cutSelectedObjects();
 
     /**

--- a/src/intelli/gui/graphscene.h
+++ b/src/intelli/gui/graphscene.h
@@ -109,6 +109,9 @@ public slots:
      */
     bool copySelectedObjects();
 
+    /// TODO
+    bool cutSelectedObjects();
+
     /**
      * @brief Pastes the selection from the clipboard. Creates an undo-redo
      * command.

--- a/src/intelli/gui/graphview.cpp
+++ b/src/intelli/gui/graphview.cpp
@@ -136,7 +136,7 @@ GraphView::GraphView(QWidget* parent) :
     deleteAction->setShortcut(gtApp->getShortCutSequence("delete"));
 
     auto* clearSelectionAction = makeSceneAction(tr("Clear Selection"),
-                                                 &GraphScene::clearSelection);
+                                                 &GraphScene::resetSelection);
     clearSelectionAction->setIcon(gt::gui::icon::clear());
     clearSelectionAction->setShortcut(Qt::Key_Escape);
 

--- a/src/intelli/gui/graphview.cpp
+++ b/src/intelli/gui/graphview.cpp
@@ -115,6 +115,11 @@ GraphView::GraphView(QWidget* parent) :
     copyAction->setIcon(gt::gui::icon::copy());
     copyAction->setShortcut(gtApp->getShortCutSequence("copy"));
 
+    auto* cutAction = makeSceneAction(tr("Cut Selection"),
+                                       &GraphScene::cutSelectedObjects);
+    cutAction->setIcon(gt::gui::icon::cut());
+    cutAction->setShortcut(gtApp->getShortCutSequence("cut"));
+
     auto* pasteAction = makeSceneAction(tr("Paste Selection"),
                                         &GraphScene::pasteObjects);
     pasteAction->setIcon(gt::gui::icon::paste());

--- a/src/intelli/gui/guidata.cpp
+++ b/src/intelli/gui/guidata.cpp
@@ -31,6 +31,16 @@ GuiData::GuiData(GtObject* parent) :
     if (!gtApp || !gtApp->devMode()) setFlag(UserHidden);
 }
 
+void
+GuiData::clearData()
+{
+    auto states = findDirectChild<LocalStateContainer*>();
+    if (states) states->clearSavedStates();
+
+    auto commentGroup = findDirectChild<CommentGroup*>();
+    if (commentGroup) commentGroup->clearComments();
+}
+
 LocalStateContainer*
 GuiData::accessLocalStates(Graph& graph)
 {
@@ -124,5 +134,11 @@ LocalStateContainer::isNodeCollapsed(NodeUuid const& nodeUuid) const
                         [&nodeUuid](GtPropertyStructInstance const& e){
         return e.ident() == nodeUuid;
     }) != m_collapsed.end();
+}
+
+void
+LocalStateContainer::clearSavedStates()
+{
+    m_collapsed.clear();
 }
 

--- a/src/intelli/gui/guidata.h
+++ b/src/intelli/gui/guidata.h
@@ -33,6 +33,8 @@ public:
 
     Q_INVOKABLE GuiData(GtObject* parent = nullptr);
 
+    void clearData();
+
     static LocalStateContainer* accessLocalStates(Graph& graph);
     static LocalStateContainer const* accessLocalStates(Graph const& graph);
 
@@ -65,6 +67,11 @@ public:
      * @return Whether the node is collapsed or expanded
      */
     bool isNodeCollapsed(NodeUuid const& nodeUuid) const;
+
+    /**
+     * @brief Removes all saved states
+     */
+    void clearSavedStates();
 
 signals:
 

--- a/src/intelli/gui/guidata.h
+++ b/src/intelli/gui/guidata.h
@@ -33,6 +33,9 @@ public:
 
     Q_INVOKABLE GuiData(GtObject* parent = nullptr);
 
+    /**
+     * @brief Clears all gui-related data for the associated graph
+     */
     void clearData();
 
     static LocalStateContainer* accessLocalStates(Graph& graph);

--- a/src/intelli/gui/nodeui.cpp
+++ b/src/intelli/gui/nodeui.cpp
@@ -596,11 +596,6 @@ NodeUI::clearGraphNode(GtObject* obj)
     Q_UNUSED(cmd);
     
     graph->clearGraph();
-
-    CommentGroup* commentGroup = GuiData::accessCommentGroup(*graph);
-    if (!commentGroup) return;
-
-    commentGroup->clearComments();
 }
 
 bool

--- a/src/intelli/utilities.h
+++ b/src/intelli/utilities.h
@@ -194,13 +194,14 @@ inline auto connectScoped(Sender sender, SignalSender signalSender,
 template<typename Sender, typename SignalSender,
          typename Reciever, typename SignalReciever>
 inline void connectOnce(Sender sender, SignalSender signalSender,
-                        Reciever reciever, SignalReciever signalReciever)
+                        Reciever reciever, SignalReciever signalReciever,
+                        Qt::ConnectionType type = Qt::DirectConnection)
 {
     auto* ctx = new QObject{reciever};
     QObject::connect(sender, signalSender, ctx, [=]() {
         signalReciever();
         ctx->deleteLater();
-    });
+    }, type);
 }
 
 } // namespace utils


### PR DESCRIPTION
Closes #283 - implemented cutting-operation in the graph view.

Cut-nodes and comments are "greyed-out"/translucent, similar to how cutting works for files and folders in most desktop environments.

<img width="835" height="388" alt="grafik" src="https://github.com/user-attachments/assets/74444541-6b66-497e-9335-a78087bc4160" />
