### PR TITLE
Fixed the incorrect inclusion of tloptional

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,6 +267,7 @@ target_link_libraries(GTlabIntelliGraph
     Qt5::Core
     GTlab::Logging
     GTlab::Gui
+    tloptional # shipped with gtlab
     PRIVATE
     Qt5::Concurrent
 )

--- a/src/intelli/gui/nodegeometry.h
+++ b/src/intelli/gui/nodegeometry.h
@@ -13,7 +13,7 @@
 #include <intelli/globals.h>
 #include <intelli/exports.h>
 
-#include <thirdparty/tl/optional.hpp>
+#include <tl/optional.hpp>
 
 #include <QPainterPath>
 #include <QPointer>

--- a/src/intelli/nodedata.h
+++ b/src/intelli/nodedata.h
@@ -14,7 +14,7 @@
 
 #include <gt_logging.h>
 #include <gt_object.h>
-#include <thirdparty/tl/optional.hpp>
+#include <tl/optional.hpp>
 
 #include <QMetaMethod>
 


### PR DESCRIPTION
The inclusion via "thirdparty" is not very portable, since it is not the standard way to include tl/optional.

This way, we should be more flexible.