### PR TITLE
Fix internal deprecated api use

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/boolnodeui.h
     intelli/gui/ui/node/doubleinputnodeui.h
     intelli/gui/ui/node/existingdirectorysourcenodeui.h
+    intelli/gui/ui/node/finddirectchildnodeui.h
     intelli/gui/ui/node/fileinputnodeui.h
     intelli/gui/ui/node/intinputnodeui.h
     intelli/gui/ui/node/logicnodeui.h
@@ -258,6 +259,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/boolnodeui.cpp
     intelli/gui/ui/node/doubleinputnodeui.cpp
     intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
+    intelli/gui/ui/node/finddirectchildnodeui.cpp
     intelli/gui/ui/node/fileinputnodeui.cpp
     intelli/gui/ui/node/intinputnodeui.cpp
     intelli/gui/ui/node/logicnodeui.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/packageui.h
     intelli/gui/ui/node/boolnodeui.h intelli/gui/ui/node/boolnodeui.cpp
     intelli/gui/ui/node/logicnodeui.h intelli/gui/ui/node/logicnodeui.cpp
+    intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp
     intelli/gui/graphics/commentobject.h
     intelli/gui/graphics/connectionobject.h
     intelli/gui/graphics/lineobject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/boolnodeui.h intelli/gui/ui/node/boolnodeui.cpp
     intelli/gui/ui/node/logicnodeui.h intelli/gui/ui/node/logicnodeui.cpp
     intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp
+    intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/gui/graphics/commentobject.h
     intelli/gui/graphics/connectionobject.h
     intelli/gui/graphics/lineobject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -154,6 +154,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/stringbuildernodeui.h intelli/gui/ui/node/stringbuildernodeui.cpp
     intelli/gui/ui/node/stringinputnodeui.h intelli/gui/ui/node/stringinputnodeui.cpp
     intelli/gui/ui/node/stringselectionnodeui.h intelli/gui/ui/node/stringselectionnodeui.cpp
+    intelli/gui/ui/node/sleepynodeui.h intelli/gui/ui/node/sleepynodeui.cpp
     intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/node/input/numberinputnode_utils.h
     intelli/gui/graphics/commentobject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,13 +141,17 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/graphcategoryui.h
     intelli/gui/ui/packageui.h
     intelli/gui/ui/node/boolnodeui.h intelli/gui/ui/node/boolnodeui.cpp
+    intelli/gui/ui/node/doubleinputnodeui.h intelli/gui/ui/node/doubleinputnodeui.cpp
     intelli/gui/ui/node/existingdirectorysourcenodeui.h intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
     intelli/gui/ui/node/fileinputnodeui.h intelli/gui/ui/node/fileinputnodeui.cpp
+    intelli/gui/ui/node/intinputnodeui.h intelli/gui/ui/node/intinputnodeui.cpp
     intelli/gui/ui/node/logicnodeui.h intelli/gui/ui/node/logicnodeui.cpp
     intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp
     intelli/gui/ui/node/numbermathnodeui.h intelli/gui/ui/node/numbermathnodeui.cpp
+    intelli/gui/ui/node/objectinputnodeui.h intelli/gui/ui/node/objectinputnodeui.cpp
     intelli/gui/ui/node/objectsinknodeui.h intelli/gui/ui/node/objectsinknodeui.cpp
     intelli/gui/ui/node/stringbuildernodeui.h intelli/gui/ui/node/stringbuildernodeui.cpp
+    intelli/gui/ui/node/stringinputnodeui.h intelli/gui/ui/node/stringinputnodeui.cpp
     intelli/gui/ui/node/stringselectionnodeui.h intelli/gui/ui/node/stringselectionnodeui.cpp
     intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/gui/graphics/commentobject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/fileinputnodeui.h intelli/gui/ui/node/fileinputnodeui.cpp
     intelli/gui/ui/node/logicnodeui.h intelli/gui/ui/node/logicnodeui.cpp
     intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp
+    intelli/gui/ui/node/numbermathnodeui.h intelli/gui/ui/node/numbermathnodeui.cpp
     intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/gui/graphics/commentobject.h
     intelli/gui/graphics/connectionobject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/packageui.h
     intelli/gui/ui/node/boolnodeui.h intelli/gui/ui/node/boolnodeui.cpp
     intelli/gui/ui/node/doubleinputnodeui.h intelli/gui/ui/node/doubleinputnodeui.cpp
+    intelli/gui/ui/node/numberinputnodeui_utils.h
     intelli/gui/ui/node/existingdirectorysourcenodeui.h intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
     intelli/gui/ui/node/fileinputnodeui.h intelli/gui/ui/node/fileinputnodeui.cpp
     intelli/gui/ui/node/intinputnodeui.h intelli/gui/ui/node/intinputnodeui.cpp
@@ -154,6 +155,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/stringinputnodeui.h intelli/gui/ui/node/stringinputnodeui.cpp
     intelli/gui/ui/node/stringselectionnodeui.h intelli/gui/ui/node/stringselectionnodeui.cpp
     intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
+    intelli/node/input/numberinputnode_utils.h
     intelli/gui/graphics/commentobject.h
     intelli/gui/graphics/connectionobject.h
     intelli/gui/graphics/lineobject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/graphcategoryui.h
     intelli/gui/ui/packageui.h
     intelli/gui/ui/node/boolnodeui.h intelli/gui/ui/node/boolnodeui.cpp
+    intelli/gui/ui/node/fileinputnodeui.h intelli/gui/ui/node/fileinputnodeui.cpp
     intelli/gui/ui/node/logicnodeui.h intelli/gui/ui/node/logicnodeui.cpp
     intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp
     intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/existingdirectorysourcenodeui.h
     intelli/gui/ui/node/finddirectchildnodeui.h
     intelli/gui/ui/node/fileinputnodeui.h
+    intelli/gui/ui/node/genericcalculatorexecnodeui.h
     intelli/gui/ui/node/intinputnodeui.h
     intelli/gui/ui/node/logicnodeui.h
     intelli/gui/ui/node/numberdisplaynodeui.h
@@ -261,6 +262,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
     intelli/gui/ui/node/finddirectchildnodeui.cpp
     intelli/gui/ui/node/fileinputnodeui.cpp
+    intelli/gui/ui/node/genericcalculatorexecnodeui.cpp
     intelli/gui/ui/node/intinputnodeui.cpp
     intelli/gui/ui/node/logicnodeui.cpp
     intelli/gui/ui/node/numberdisplaynodeui.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/graphcategoryui.h
     intelli/gui/ui/packageui.h
     intelli/gui/ui/node/boolnodeui.h intelli/gui/ui/node/boolnodeui.cpp
+    intelli/gui/ui/node/existingdirectorysourcenodeui.h intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
     intelli/gui/ui/node/fileinputnodeui.h intelli/gui/ui/node/fileinputnodeui.cpp
     intelli/gui/ui/node/logicnodeui.h intelli/gui/ui/node/logicnodeui.cpp
     intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,6 +147,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp
     intelli/gui/ui/node/numbermathnodeui.h intelli/gui/ui/node/numbermathnodeui.cpp
     intelli/gui/ui/node/objectsinknodeui.h intelli/gui/ui/node/objectsinknodeui.cpp
+    intelli/gui/ui/node/stringbuildernodeui.h intelli/gui/ui/node/stringbuildernodeui.cpp
     intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/gui/graphics/commentobject.h
     intelli/gui/graphics/connectionobject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,22 +140,22 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/guidataui.h
     intelli/gui/ui/graphcategoryui.h
     intelli/gui/ui/packageui.h
-    intelli/gui/ui/node/boolnodeui.h intelli/gui/ui/node/boolnodeui.cpp
-    intelli/gui/ui/node/doubleinputnodeui.h intelli/gui/ui/node/doubleinputnodeui.cpp
+    intelli/gui/ui/node/boolnodeui.h
+    intelli/gui/ui/node/doubleinputnodeui.h
+    intelli/gui/ui/node/existingdirectorysourcenodeui.h
+    intelli/gui/ui/node/fileinputnodeui.h
+    intelli/gui/ui/node/intinputnodeui.h
+    intelli/gui/ui/node/logicnodeui.h
+    intelli/gui/ui/node/numberdisplaynodeui.h
+    intelli/gui/ui/node/numbermathnodeui.h
+    intelli/gui/ui/node/objectinputnodeui.h
+    intelli/gui/ui/node/objectsinknodeui.h
+    intelli/gui/ui/node/sleepynodeui.h
+    intelli/gui/ui/node/stringbuildernodeui.h
+    intelli/gui/ui/node/stringinputnodeui.h
+    intelli/gui/ui/node/stringselectionnodeui.h
+    intelli/gui/ui/node/textdisplaynodeui.h
     intelli/gui/ui/node/numberinputnodeui_utils.h
-    intelli/gui/ui/node/existingdirectorysourcenodeui.h intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
-    intelli/gui/ui/node/fileinputnodeui.h intelli/gui/ui/node/fileinputnodeui.cpp
-    intelli/gui/ui/node/intinputnodeui.h intelli/gui/ui/node/intinputnodeui.cpp
-    intelli/gui/ui/node/logicnodeui.h intelli/gui/ui/node/logicnodeui.cpp
-    intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp
-    intelli/gui/ui/node/numbermathnodeui.h intelli/gui/ui/node/numbermathnodeui.cpp
-    intelli/gui/ui/node/objectinputnodeui.h intelli/gui/ui/node/objectinputnodeui.cpp
-    intelli/gui/ui/node/objectsinknodeui.h intelli/gui/ui/node/objectsinknodeui.cpp
-    intelli/gui/ui/node/stringbuildernodeui.h intelli/gui/ui/node/stringbuildernodeui.cpp
-    intelli/gui/ui/node/stringinputnodeui.h intelli/gui/ui/node/stringinputnodeui.cpp
-    intelli/gui/ui/node/stringselectionnodeui.h intelli/gui/ui/node/stringselectionnodeui.cpp
-    intelli/gui/ui/node/sleepynodeui.h intelli/gui/ui/node/sleepynodeui.cpp
-    intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/node/input/numberinputnode_utils.h
     intelli/gui/graphics/commentobject.h
     intelli/gui/graphics/connectionobject.h
@@ -255,6 +255,21 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/guidataui.cpp
     intelli/gui/ui/graphcategoryui.cpp
     intelli/gui/ui/packageui.cpp
+    intelli/gui/ui/node/boolnodeui.cpp
+    intelli/gui/ui/node/doubleinputnodeui.cpp
+    intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
+    intelli/gui/ui/node/fileinputnodeui.cpp
+    intelli/gui/ui/node/intinputnodeui.cpp
+    intelli/gui/ui/node/logicnodeui.cpp
+    intelli/gui/ui/node/numberdisplaynodeui.cpp
+    intelli/gui/ui/node/numbermathnodeui.cpp
+    intelli/gui/ui/node/objectinputnodeui.cpp
+    intelli/gui/ui/node/objectsinknodeui.cpp
+    intelli/gui/ui/node/sleepynodeui.cpp
+    intelli/gui/ui/node/stringbuildernodeui.cpp
+    intelli/gui/ui/node/stringinputnodeui.cpp
+    intelli/gui/ui/node/stringselectionnodeui.cpp
+    intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/gui/graphics/commentobject.cpp
     intelli/gui/graphics/connectionobject.cpp
     intelli/gui/graphics/graphicsobject.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/numbermathnodeui.h intelli/gui/ui/node/numbermathnodeui.cpp
     intelli/gui/ui/node/objectsinknodeui.h intelli/gui/ui/node/objectsinknodeui.cpp
     intelli/gui/ui/node/stringbuildernodeui.h intelli/gui/ui/node/stringbuildernodeui.cpp
+    intelli/gui/ui/node/stringselectionnodeui.h intelli/gui/ui/node/stringselectionnodeui.cpp
     intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/gui/graphics/commentobject.h
     intelli/gui/graphics/connectionobject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,6 +146,7 @@ add_gtlab_module(GTlabIntelliGraph MODULE_ID "IntelliGraph"
     intelli/gui/ui/node/logicnodeui.h intelli/gui/ui/node/logicnodeui.cpp
     intelli/gui/ui/node/numberdisplaynodeui.h intelli/gui/ui/node/numberdisplaynodeui.cpp
     intelli/gui/ui/node/numbermathnodeui.h intelli/gui/ui/node/numbermathnodeui.cpp
+    intelli/gui/ui/node/objectsinknodeui.h intelli/gui/ui/node/objectsinknodeui.cpp
     intelli/gui/ui/node/textdisplaynodeui.h intelli/gui/ui/node/textdisplaynodeui.cpp
     intelli/gui/graphics/commentobject.h
     intelli/gui/graphics/connectionobject.h

--- a/src/intelli/gui/ui/node/doubleinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/doubleinputnodeui.cpp
@@ -8,8 +8,9 @@
 #include <intelli/gui/ui/node/doubleinputnodeui.h>
 
 #include <intelli/gui/graphics/nodeobject.h>
-#include <intelli/gui/widgets/doubleinputwidget.h>
 #include <intelli/node/input/doubleinput.h>
+#include <intelli/gui/ui/node/numberinputnodeui_utils.h>
+#include <intelli/gui/widgets/doubleinputwidget.h>
 
 #include <QGraphicsWidget>
 
@@ -26,43 +27,6 @@ DoubleInputNodeUI::centralWidgetFactory(Node const& n) const
         auto* node = qobject_cast<DoubleInputNode*>(&source);
         if (!node) return nullptr;
 
-        using InputMode = DoubleInputWidget::InputMode;
-
-        auto* w = new DoubleInputWidget(static_cast<InputMode>(node->inputModeValue()));
-
-        auto updateRange = [node, w]() {
-            w->setRange(node->value(), node->lowerBound(), node->upperBound());
-        };
-
-        auto updateMode = [node, w]() {
-            w->setInputMode(static_cast<InputMode>(node->inputModeValue()));
-            node->setUseBounds(w->useBounds());
-        };
-
-        QObject::connect(w, &DoubleInputWidget::valueComitted,
-                         w, [node, w]() {
-            double newVal = w->value();
-            if (node->value() != newVal) node->setValue(newVal);
-        });
-        QObject::connect(w, &DoubleInputWidget::minChanged,
-                         w, [node, w]() {
-            double newVal = w->min();
-            if (node->lowerBound() != newVal) node->setLowerBound(newVal);
-        });
-        QObject::connect(w, &DoubleInputWidget::maxChanged,
-                         w, [node, w]() {
-            double newVal = w->max();
-            if (node->upperBound() != newVal) node->setUpperBound(newVal);
-        });
-
-        QObject::connect(node, &DoubleInputNode::rangeChanged,
-                         w, updateRange);
-        QObject::connect(node, &DoubleInputNode::inputModeChanged,
-                         w, updateMode);
-
-        updateRange();
-        updateMode();
-
-        return convertToGraphicsWidget(std::unique_ptr<QWidget>(w), object);
+        return ui::detail::makeNumberInputWidget<DoubleInputNode, DoubleInputWidget, double>(node, object);
     };
 }

--- a/src/intelli/gui/ui/node/doubleinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/doubleinputnodeui.cpp
@@ -1,0 +1,68 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/doubleinputnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/gui/widgets/doubleinputwidget.h>
+#include <intelli/node/input/doubleinput.h>
+
+#include <QGraphicsWidget>
+
+using namespace intelli;
+
+DoubleInputNodeUI::DoubleInputNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+DoubleInputNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<DoubleInputNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<DoubleInputNode*>(&source);
+        if (!node) return nullptr;
+
+        using InputMode = DoubleInputWidget::InputMode;
+
+        auto* w = new DoubleInputWidget(static_cast<InputMode>(node->inputModeValue()));
+
+        auto updateRange = [node, w]() {
+            w->setRange(node->value(), node->lowerBound(), node->upperBound());
+        };
+
+        auto updateMode = [node, w]() {
+            w->setInputMode(static_cast<InputMode>(node->inputModeValue()));
+            node->setUseBounds(w->useBounds());
+        };
+
+        QObject::connect(w, &DoubleInputWidget::valueComitted,
+                         w, [node, w]() {
+            double newVal = w->value();
+            if (node->value() != newVal) node->setValue(newVal);
+        });
+        QObject::connect(w, &DoubleInputWidget::minChanged,
+                         w, [node, w]() {
+            double newVal = w->min();
+            if (node->lowerBound() != newVal) node->setLowerBound(newVal);
+        });
+        QObject::connect(w, &DoubleInputWidget::maxChanged,
+                         w, [node, w]() {
+            double newVal = w->max();
+            if (node->upperBound() != newVal) node->setUpperBound(newVal);
+        });
+
+        QObject::connect(node, &DoubleInputNode::rangeChanged,
+                         w, updateRange);
+        QObject::connect(node, &DoubleInputNode::inputModeChanged,
+                         w, updateMode);
+
+        updateRange();
+        updateMode();
+
+        return convertToGraphicsWidget(std::unique_ptr<QWidget>(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/doubleinputnodeui.h
+++ b/src/intelli/gui/ui/node/doubleinputnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_DOUBLEINPUTNODEUI_H
+#define GT_INTELLI_DOUBLEINPUTNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class DoubleInputNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE DoubleInputNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_DOUBLEINPUTNODEUI_H

--- a/src/intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
+++ b/src/intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
@@ -1,0 +1,87 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/existingdirectorysourcenodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/node/existingdirectorysource.h>
+
+#include <gt_abstractproperty.h>
+#include <gt_existingdirectoryproperty.h>
+#include <gt_filedialog.h>
+#include <gt_propertyfilechoosereditor.h>
+
+#include <QApplication>
+#include <QGraphicsWidget>
+#include <QPushButton>
+
+using namespace intelli;
+
+ExistingDirectorySourceNodeUI::ExistingDirectorySourceNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+ExistingDirectorySourceNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<ExistingDirectorySourceNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<ExistingDirectorySourceNode*>(&source);
+        if (!node) return nullptr;
+
+        // Editor widget is embedded via QGraphicsProxyWidget.
+        auto w = std::make_unique<GtPropertyFileChooserEditor>();
+        w->setMinimumWidth(120);
+
+        // Keep a dedicated UI property so the editor can own lifetime/updates.
+        auto* prop = new GtExistingDirectoryProperty("ui_directory",
+                                                     QObject::tr("Directory"),
+                                                     QObject::tr("Directory"));
+        prop->setParent(w.get());
+        prop->setVal(node->directory());
+        w->setFileChooserProperty(prop);
+
+        // Sync node -> UI.
+        QObject::connect(node, &ExistingDirectorySourceNode::directoryChanged,
+                         w.get(), [prop](QString const& path) {
+            if (prop->get() == path) return;
+            prop->setVal(path);
+        });
+
+        // Sync UI -> node.
+        QObject::connect(prop, &GtAbstractProperty::changed,
+                         w.get(), [node, prop]() {
+            node->setDirectory(prop->get());
+        });
+
+        auto const& buttons = w->findChildren<QPushButton*>();
+        if (!buttons.empty())
+        {
+            // Override the editor's select-button handler so we can choose
+            // a stable top-level parent for the dialog in the graphics scene.
+            QPushButton* btn = buttons.last();
+
+            if (btn)
+            {
+                btn->disconnect();
+                QObject::connect(btn, &QPushButton::clicked, w.get(), [node, w_ = w.get(), prop]() {
+                    QWidget* dialogParent = QApplication::activeWindow();
+                    if (!dialogParent) dialogParent = w_;
+
+                    auto const directory = GtFileDialog::getExistingDirectory(
+                        dialogParent,
+                        QObject::tr("Choose Directory"),
+                        node->directory());
+                    if (directory.isEmpty()) return;
+
+                    prop->setVal(directory);
+                });
+            }
+        }
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/existingdirectorysourcenodeui.h
+++ b/src/intelli/gui/ui/node/existingdirectorysourcenodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_EXISTINGDIRECTORYSOURCENODEUI_H
+#define GT_INTELLI_EXISTINGDIRECTORYSOURCENODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class ExistingDirectorySourceNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE ExistingDirectorySourceNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_EXISTINGDIRECTORYSOURCENODEUI_H

--- a/src/intelli/gui/ui/node/fileinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/fileinputnodeui.cpp
@@ -1,0 +1,96 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/fileinputnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/gui/utilities.h>
+#include <intelli/node/input/fileinput.h>
+
+#include <gt_abstractproperty.h>
+#include <gt_filedialog.h>
+#include <gt_openfilenameproperty.h>
+#include <gt_propertyfilechoosereditor.h>
+
+#include <QApplication>
+#include <QGraphicsWidget>
+#include <QLayout>
+#include <QPushButton>
+
+using namespace intelli;
+
+FileInputNodeUI::FileInputNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+FileInputNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<FileInputNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<FileInputNode*>(&source);
+        if (!node) return nullptr;
+
+        auto b = utils::makeWidgetWithLayout();
+        auto* lay = b->layout();
+
+        auto* w = new GtPropertyFileChooserEditor();
+        lay->addWidget(w);
+
+        w->setMinimumWidth(150);
+
+        auto* fileProp = new GtOpenFileNameProperty("ui_file",
+                                                    QObject::tr("File"),
+                                                    QObject::tr("File Path"),
+                                                    QStringList{});
+        fileProp->setParent(w);
+        fileProp->setVal(node->selectedFile());
+        w->setFileChooserProperty(fileProp);
+
+        auto const updateWidget = [w, b_ = b.get()](bool connected) {
+            w->setVisible(!connected);
+            b_->setMinimumWidth(connected ? 10 : w->minimumWidth());
+            b_->resize(b_->minimumSize());
+        };
+
+        QObject::connect(node, &FileInputNode::fileNameInputConnectionChanged, w, updateWidget);
+        QObject::connect(node, &FileInputNode::selectedFileChanged, w, [fileProp](QString const& path) {
+            if (fileProp->get() == path) return;
+            fileProp->setVal(path);
+        });
+        QObject::connect(fileProp, &GtAbstractProperty::changed, w, [node, fileProp]() {
+            node->setSelectedFile(fileProp->get());
+        });
+        updateWidget(node->isFileNameInputConnected());
+
+        auto const& btns = w->findChildren<QPushButton*>();
+        if (!btns.empty())
+        {
+            // Override the editor's select-button handler so we can choose
+            // a stable top-level parent for the dialog in the graphics scene.
+            // In GtPropertyFileChooserEditor, the select button is added last.
+            QPushButton* btn = btns.last();
+
+            if (btn)
+            {
+                btn->disconnect();
+                QObject::connect(btn, &QPushButton::clicked, w, [node, w, fileProp]() {
+                    QWidget* dialogParent = QApplication::activeWindow();
+                    if (!dialogParent) dialogParent = w;
+
+                    auto const fileName = GtFileDialog::getOpenFileName(dialogParent,
+                                                                        QObject::tr("Choose File"),
+                                                                        node->dialogDirectory());
+                    if (fileName.isEmpty()) return;
+
+                    fileProp->setVal(fileName);
+                });
+            }
+        }
+
+        return convertToGraphicsWidget(std::move(b), object);
+    };
+}

--- a/src/intelli/gui/ui/node/fileinputnodeui.h
+++ b/src/intelli/gui/ui/node/fileinputnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_FILEINPUTNODEUI_H
+#define GT_INTELLI_FILEINPUTNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class FileInputNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE FileInputNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_FILEINPUTNODEUI_H

--- a/src/intelli/gui/ui/node/finddirectchildnodeui.cpp
+++ b/src/intelli/gui/ui/node/finddirectchildnodeui.cpp
@@ -1,0 +1,61 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/finddirectchildnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/gui/widgets/finddirectchildwidget.h>
+#include <intelli/node/finddirectchild.h>
+
+#include <QGraphicsWidget>
+
+using namespace intelli;
+
+FindDirectChildNodeUI::FindDirectChildNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+FindDirectChildNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<FindDirectChildNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<FindDirectChildNode*>(&source);
+        if (!node) return nullptr;
+
+        auto w = std::make_unique<FindDirectChildWidget>();
+
+        w->updateNameCompleter(node->inputObject());
+
+        QObject::connect(w.get(), &FindDirectChildWidget::updateClass,
+                         w.get(), [node](QString const& newClass) {
+            node->setTargetClassName(newClass);
+        });
+        QObject::connect(node, &FindDirectChildNode::targetClassNameChanged,
+                         w.get(), [w_ = w.get()](QString const&) {
+            w_->updateClassText();
+        });
+
+        QObject::connect(w.get(), &FindDirectChildWidget::updateObjectName,
+                         w.get(), [node](QString const& newObjName) {
+            node->setTargetObjectName(newObjName);
+        });
+        QObject::connect(node, &FindDirectChildNode::targetObjectNameChanged,
+                         w.get(), [w_ = w.get()](QString const&) {
+            w_->updateNameText();
+        });
+
+        QObject::connect(node, &Node::inputDataRecieved,
+                         w.get(), [node, w_ = w.get()](PortId) {
+            w_->updateNameCompleter(node->inputObject());
+        });
+
+        w->setClassNameWidget(node->targetClassName());
+        w->setObjectNameWidget(node->targetObjectName());
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/finddirectchildnodeui.h
+++ b/src/intelli/gui/ui/node/finddirectchildnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_FINDDIRECTCHILDNODEUI_H
+#define GT_INTELLI_FINDDIRECTCHILDNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class FindDirectChildNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE FindDirectChildNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_FINDDIRECTCHILDNODEUI_H

--- a/src/intelli/gui/ui/node/genericcalculatorexecnodeui.cpp
+++ b/src/intelli/gui/ui/node/genericcalculatorexecnodeui.cpp
@@ -1,0 +1,91 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/genericcalculatorexecnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/node/genericcalculatorexec.h>
+#include <intelli/nodedatainterface.h>
+
+#include <gt_coreapplication.h>
+#include <gt_project.h>
+#include <gt_propertytreeview.h>
+#include <gt_stylesheets.h>
+
+#include <QComboBox>
+#include <QGraphicsWidget>
+#include <QVBoxLayout>
+
+using namespace intelli;
+
+GenericCalculatorExecNodeUI::GenericCalculatorExecNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+GenericCalculatorExecNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<GenericCalculatorExecNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<GenericCalculatorExecNode*>(&source);
+        if (!node) return nullptr;
+
+        auto w = std::make_unique<QWidget>();
+        auto* lay = new QVBoxLayout;
+        w->setLayout(lay);
+        lay->setContentsMargins(0, 0, 0, 0);
+
+        auto* edit = new QComboBox;
+        edit->addItems(GenericCalculatorExecNode::classIdents());
+        edit->setStyleSheet(gt::gui::stylesheet::comboBox());
+        lay->addWidget(edit);
+
+        auto* model = exec::nodeDataInterface(*node);
+        GtObject* scope = model ? model->scope() : static_cast<GtObject*>(gtApp->currentProject());
+        assert(scope);
+
+        auto* view = new GtPropertyTreeView(scope);
+        view->setAnimated(false);
+        lay->addWidget(view);
+
+        auto updateView = [view, node](){
+            view->setObject(nullptr);
+
+            auto obj = node->currentObject();
+            if (obj)
+            {
+                view->setObject(obj);
+                // collapse first category
+                view->collapse(view->model()->index(0, 0, view->rootIndex()));
+
+                QObject::connect(obj, qOverload<GtObject*, GtAbstractProperty*>(&GtObject::dataChanged),
+                                 node, &GenericCalculatorExecNode::onCurrentObjectDataChanged,
+                                 Qt::UniqueConnection);
+            }
+        };
+
+        auto const updateClass = [node, edit](){
+            node->setClassName(GenericCalculatorExecNode::classNameFromIdent(edit->currentText()));
+        };
+        auto const updateClassText = [node, edit](){
+            edit->setCurrentText(GenericCalculatorExecNode::identFromClassName(node->className()));
+        };
+
+        QObject::connect(edit, &QComboBox::currentTextChanged,
+                         edit, updateClass);
+        QObject::connect(node, &GenericCalculatorExecNode::classNameChanged,
+                         edit, updateClassText);
+        QObject::connect(node, &GenericCalculatorExecNode::currentObjectChanged,
+                         view, updateView);
+
+        node->syncConnectedPorts();
+
+        node->className().isEmpty() ? updateClass() : updateClassText();
+        updateView();
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/genericcalculatorexecnodeui.h
+++ b/src/intelli/gui/ui/node/genericcalculatorexecnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_GENERICCALCULATOREXECNODEUI_H
+#define GT_INTELLI_GENERICCALCULATOREXECNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class GenericCalculatorExecNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE GenericCalculatorExecNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_GENERICCALCULATOREXECNODEUI_H

--- a/src/intelli/gui/ui/node/intinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/intinputnodeui.cpp
@@ -8,8 +8,9 @@
 #include <intelli/gui/ui/node/intinputnodeui.h>
 
 #include <intelli/gui/graphics/nodeobject.h>
-#include <intelli/gui/widgets/intinputwidget.h>
 #include <intelli/node/input/intinput.h>
+#include <intelli/gui/ui/node/numberinputnodeui_utils.h>
+#include <intelli/gui/widgets/intinputwidget.h>
 
 #include <QGraphicsWidget>
 
@@ -26,43 +27,6 @@ IntInputNodeUI::centralWidgetFactory(Node const& n) const
         auto* node = qobject_cast<IntInputNode*>(&source);
         if (!node) return nullptr;
 
-        using InputMode = IntInputWidget::InputMode;
-
-        auto* w = new IntInputWidget(static_cast<InputMode>(node->inputModeValue()));
-
-        auto updateRange = [node, w]() {
-            w->setRange(node->value(), node->lowerBound(), node->upperBound());
-        };
-
-        auto updateMode = [node, w]() {
-            w->setInputMode(static_cast<InputMode>(node->inputModeValue()));
-            node->setUseBounds(w->useBounds());
-        };
-
-        QObject::connect(w, &IntInputWidget::valueComitted,
-                         w, [node, w]() {
-            int newVal = w->value();
-            if (node->value() != newVal) node->setValue(newVal);
-        });
-        QObject::connect(w, &IntInputWidget::minChanged,
-                         w, [node, w]() {
-            int newVal = w->min();
-            if (node->lowerBound() != newVal) node->setLowerBound(newVal);
-        });
-        QObject::connect(w, &IntInputWidget::maxChanged,
-                         w, [node, w]() {
-            int newVal = w->max();
-            if (node->upperBound() != newVal) node->setUpperBound(newVal);
-        });
-
-        QObject::connect(node, &IntInputNode::rangeChanged,
-                         w, updateRange);
-        QObject::connect(node, &IntInputNode::inputModeChanged,
-                         w, updateMode);
-
-        updateRange();
-        updateMode();
-
-        return convertToGraphicsWidget(std::unique_ptr<QWidget>(w), object);
+        return ui::detail::makeNumberInputWidget<IntInputNode, IntInputWidget, int>(node, object);
     };
 }

--- a/src/intelli/gui/ui/node/intinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/intinputnodeui.cpp
@@ -1,0 +1,68 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/intinputnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/gui/widgets/intinputwidget.h>
+#include <intelli/node/input/intinput.h>
+
+#include <QGraphicsWidget>
+
+using namespace intelli;
+
+IntInputNodeUI::IntInputNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+IntInputNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<IntInputNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<IntInputNode*>(&source);
+        if (!node) return nullptr;
+
+        using InputMode = IntInputWidget::InputMode;
+
+        auto* w = new IntInputWidget(static_cast<InputMode>(node->inputModeValue()));
+
+        auto updateRange = [node, w]() {
+            w->setRange(node->value(), node->lowerBound(), node->upperBound());
+        };
+
+        auto updateMode = [node, w]() {
+            w->setInputMode(static_cast<InputMode>(node->inputModeValue()));
+            node->setUseBounds(w->useBounds());
+        };
+
+        QObject::connect(w, &IntInputWidget::valueComitted,
+                         w, [node, w]() {
+            int newVal = w->value();
+            if (node->value() != newVal) node->setValue(newVal);
+        });
+        QObject::connect(w, &IntInputWidget::minChanged,
+                         w, [node, w]() {
+            int newVal = w->min();
+            if (node->lowerBound() != newVal) node->setLowerBound(newVal);
+        });
+        QObject::connect(w, &IntInputWidget::maxChanged,
+                         w, [node, w]() {
+            int newVal = w->max();
+            if (node->upperBound() != newVal) node->setUpperBound(newVal);
+        });
+
+        QObject::connect(node, &IntInputNode::rangeChanged,
+                         w, updateRange);
+        QObject::connect(node, &IntInputNode::inputModeChanged,
+                         w, updateMode);
+
+        updateRange();
+        updateMode();
+
+        return convertToGraphicsWidget(std::unique_ptr<QWidget>(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/intinputnodeui.h
+++ b/src/intelli/gui/ui/node/intinputnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_INTINPUTNODEUI_H
+#define GT_INTELLI_INTINPUTNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class IntInputNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE IntInputNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_INTINPUTNODEUI_H

--- a/src/intelli/gui/ui/node/numberdisplaynodeui.cpp
+++ b/src/intelli/gui/ui/node/numberdisplaynodeui.cpp
@@ -1,0 +1,44 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/numberdisplaynodeui.h>
+
+#include <intelli/node/numberdisplay.h>
+#include <intelli/gui/graphics/nodeobject.h>
+
+#include <gt_lineedit.h>
+
+#include <QGraphicsWidget>
+
+using namespace intelli;
+
+NumberDisplayNodeUI::NumberDisplayNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+NumberDisplayNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<NumberDisplayNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<NumberDisplayNode*>(&source);
+        if (!node) return nullptr;
+
+        auto w = std::make_unique<GtLineEdit>();
+        w->setReadOnly(true);
+        w->setMinimumWidth(75);
+        w->resize(w->minimumSizeHint());
+
+        auto const updateText = [node, w_ = w.get()]() {
+            w_->setText(QString::number(node->displayValue()));
+        };
+
+        QObject::connect(node, &Node::evaluated, w.get(), updateText);
+        updateText();
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/numberdisplaynodeui.h
+++ b/src/intelli/gui/ui/node/numberdisplaynodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_NUMBERDISPLAYNODEUI_H
+#define GT_INTELLI_NUMBERDISPLAYNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class NumberDisplayNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE NumberDisplayNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_NUMBERDISPLAYNODEUI_H

--- a/src/intelli/gui/ui/node/numberinputnodeui_utils.h
+++ b/src/intelli/gui/ui/node/numberinputnodeui_utils.h
@@ -1,0 +1,69 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_NUMBERINPUTNODEUI_UTILS_H
+#define GT_INTELLI_NUMBERINPUTNODEUI_UTILS_H
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/gui/nodeui.h>
+
+#include <QWidget>
+
+namespace intelli
+{
+namespace ui
+{
+namespace detail
+{
+
+template <typename NodeT, typename WidgetT, typename ValueT>
+NodeUI::QGraphicsWidgetPtr
+makeNumberInputWidget(NodeT* node, NodeGraphicsObject& object)
+{
+    using InputMode = typename WidgetT::InputMode;
+
+    auto* w = new WidgetT(static_cast<InputMode>(node->inputModeValue()));
+
+    auto updateRange = [node, w]() {
+        w->setRange(node->value(), node->lowerBound(), node->upperBound());
+    };
+
+    auto updateMode = [node, w]() {
+        w->setInputMode(static_cast<InputMode>(node->inputModeValue()));
+        node->setUseBounds(w->useBounds());
+    };
+
+    QObject::connect(w, &WidgetT::valueComitted,
+                     w, [node, w]() {
+        ValueT newVal = w->value();
+        if (node->value() != newVal) node->setValue(newVal);
+    });
+    QObject::connect(w, &WidgetT::minChanged,
+                     w, [node, w]() {
+        ValueT newVal = w->min();
+        if (node->lowerBound() != newVal) node->setLowerBound(newVal);
+    });
+    QObject::connect(w, &WidgetT::maxChanged,
+                     w, [node, w]() {
+        ValueT newVal = w->max();
+        if (node->upperBound() != newVal) node->setUpperBound(newVal);
+    });
+
+    QObject::connect(node, &NodeT::rangeChanged, w, updateRange);
+    QObject::connect(node, &NodeT::inputModeChanged, w, updateMode);
+
+    updateRange();
+    updateMode();
+
+    return NodeUI::convertToGraphicsWidget(std::unique_ptr<QWidget>(w), object);
+}
+
+} // namespace detail
+} // namespace ui
+} // namespace intelli
+
+#endif // GT_INTELLI_NUMBERINPUTNODEUI_UTILS_H

--- a/src/intelli/gui/ui/node/numbermathnodeui.cpp
+++ b/src/intelli/gui/ui/node/numbermathnodeui.cpp
@@ -1,0 +1,79 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/numbermathnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/gui/utilities.h>
+#include <intelli/node/numbermath.h>
+
+#include <QComboBox>
+#include <QGraphicsWidget>
+#include <QLayout>
+
+using namespace intelli;
+
+NumberMathNodeUI::NumberMathNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+NumberMathNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<NumberMathNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<NumberMathNode*>(&source);
+        if (!node) return nullptr;
+
+        auto base = utils::makeWidgetWithLayout();
+        auto* combo = new QComboBox();
+        base->layout()->addWidget(combo);
+        combo->addItems(QStringList{"+", "-", "*", "/", "pow"});
+
+        auto const toText = [](NumberMathNode::MathOperation op) {
+            switch (op)
+            {
+            case NumberMathNode::Minus:
+                return QStringLiteral("-");
+            case NumberMathNode::Divide:
+                return QStringLiteral("/");
+            case NumberMathNode::Multiply:
+                return QStringLiteral("*");
+            case NumberMathNode::Power:
+                return QStringLiteral("pow");
+            case NumberMathNode::Plus:
+                break;
+            }
+            return QStringLiteral("+");
+        };
+
+        auto const fromText = [](QString const& text) {
+            if (text == QStringLiteral("-")) return NumberMathNode::Minus;
+            if (text == QStringLiteral("*")) return NumberMathNode::Multiply;
+            if (text == QStringLiteral("/")) return NumberMathNode::Divide;
+            if (text == QStringLiteral("pow")) return NumberMathNode::Power;
+            return NumberMathNode::Plus;
+        };
+
+        auto const update = [node, combo, toText]() {
+            combo->setCurrentText(toText(node->operation()));
+        };
+
+        QObject::connect(node, &NumberMathNode::operationChanged,
+                         combo, update);
+
+        QObject::connect(combo, &QComboBox::currentTextChanged,
+                         combo, [node, fromText](QString const& text) {
+            auto next = fromText(text);
+            if (next == node->operation()) return;
+            node->setOperation(next);
+        });
+
+        update();
+
+        return convertToGraphicsWidget(std::move(base), object);
+    };
+}

--- a/src/intelli/gui/ui/node/numbermathnodeui.h
+++ b/src/intelli/gui/ui/node/numbermathnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_NUMBERMATHNODEUI_H
+#define GT_INTELLI_NUMBERMATHNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class NumberMathNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE NumberMathNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_NUMBERMATHNODEUI_H

--- a/src/intelli/gui/ui/node/objectinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/objectinputnodeui.cpp
@@ -1,0 +1,50 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/objectinputnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/node/input/objectinput.h>
+#include <intelli/nodedatainterface.h>
+
+#include <gt_propertyobjectlinkeditor.h>
+
+#include <QGraphicsWidget>
+
+using namespace intelli;
+
+ObjectInputNodeUI::ObjectInputNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+ObjectInputNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<ObjectInputNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<ObjectInputNode*>(&source);
+        if (!node) return nullptr;
+
+        auto w = std::make_unique<GtPropertyObjectLinkEditor>();
+        w->setObjectLinkProperty(&node->objectProperty());
+
+        auto updateScope = [node, w_ = w.get()]() {
+            auto* model = exec::nodeDataInterface(*node);
+            w_->setScope(model ? model->scope() : node->objectProperty().object());
+        };
+        auto updateText = [w_ = w.get()]() {
+            w_->updateText();
+        };
+
+        QObject::connect(node, &Node::evaluated, w.get(), updateScope);
+        QObject::connect(node, &Node::evaluated, w.get(), updateText);
+
+        updateScope();
+        updateText();
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/objectinputnodeui.h
+++ b/src/intelli/gui/ui/node/objectinputnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_OBJECTINPUTNODEUI_H
+#define GT_INTELLI_OBJECTINPUTNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class ObjectInputNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE ObjectInputNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_OBJECTINPUTNODEUI_H

--- a/src/intelli/gui/ui/node/objectsinknodeui.cpp
+++ b/src/intelli/gui/ui/node/objectsinknodeui.cpp
@@ -1,0 +1,42 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/objectsinknodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/node/objectsink.h>
+
+#include <QGraphicsWidget>
+#include <QPushButton>
+
+using namespace intelli;
+
+ObjectSinkNodeUI::ObjectSinkNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+ObjectSinkNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<ObjectSink const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<ObjectSink*>(&source);
+        if (!node) return nullptr;
+
+        auto w = std::make_unique<QPushButton>(QObject::tr("Export"));
+        w->setEnabled(node->canExport());
+
+        QObject::connect(node, &ObjectSink::exportEnabledChanged,
+                         w.get(), [w_ = w.get()](bool enabled) {
+            w_->setEnabled(enabled);
+        });
+
+        QObject::connect(w.get(), &QPushButton::clicked,
+                         w.get(), [node]() { node->exportObject(); });
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/objectsinknodeui.h
+++ b/src/intelli/gui/ui/node/objectsinknodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_OBJECTSINKNODEUI_H
+#define GT_INTELLI_OBJECTSINKNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class ObjectSinkNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE ObjectSinkNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_OBJECTSINKNODEUI_H

--- a/src/intelli/gui/ui/node/sleepynodeui.cpp
+++ b/src/intelli/gui/ui/node/sleepynodeui.cpp
@@ -1,0 +1,53 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/sleepynodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/node/sleepy.h>
+
+#include <gt_icons.h>
+
+#include <QGraphicsWidget>
+#include <QLabel>
+
+using namespace intelli;
+
+SleepyNodeUI::SleepyNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+SleepyNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<SleepyNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<SleepyNode*>(&source);
+        if (!node) return nullptr;
+
+        auto w = std::make_unique<QLabel>();
+
+        auto reset = [w_ = w.get(), node](){
+            if (node->hasInputData())
+                w_->setPixmap(gt::gui::icon::check().pixmap(20, 20));
+            else
+                w_->setPixmap(gt::gui::icon::cross().pixmap(20, 20));
+        };
+
+        auto update = [w_ = w.get()](int progress){
+            w_->setPixmap(progress != 100 ?
+                gt::gui::icon::processRunningIcon(progress).pixmap(20, 20) :
+                gt::gui::icon::check().pixmap(20, 20));
+        };
+
+        QObject::connect(node, &SleepyNode::timePassed, w.get(), update);
+        QObject::connect(node, &Node::inputDataRecieved, w.get(), reset);
+
+        reset();
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/sleepynodeui.h
+++ b/src/intelli/gui/ui/node/sleepynodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_SLEEPYNODEUI_H
+#define GT_INTELLI_SLEEPYNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class SleepyNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE SleepyNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_SLEEPYNODEUI_H

--- a/src/intelli/gui/ui/node/stringbuildernodeui.cpp
+++ b/src/intelli/gui/ui/node/stringbuildernodeui.cpp
@@ -1,0 +1,58 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/stringbuildernodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/gui/utilities.h>
+#include <intelli/node/stringbuilder.h>
+
+#include <gt_lineedit.h>
+
+#include <QGraphicsWidget>
+#include <QLayout>
+
+using namespace intelli;
+
+StringBuilderNodeUI::StringBuilderNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+StringBuilderNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<StringBuilderNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<StringBuilderNode*>(&source);
+        if (!node) return nullptr;
+
+        auto base = utils::makeWidgetWithLayout();
+        auto* lay = base->layout();
+
+        auto* edit = new GtLineEdit();
+        edit->setPlaceholderText(QStringLiteral("%1/%2"));
+        edit->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        edit->setMinimumWidth(50);
+        lay->addWidget(edit);
+
+        auto const updatePattern = [node, edit]() {
+            QString const& text = edit->text();
+            if (node->pattern() != text) node->setPattern(text);
+        };
+        auto const updateText = [node, edit]() {
+            QString const& text = node->pattern();
+            if (edit->text() != text) edit->setText(text);
+        };
+
+        QObject::connect(edit, &GtLineEdit::focusOut, edit, updatePattern);
+        QObject::connect(edit, &GtLineEdit::clearFocusOut, edit, updatePattern);
+        QObject::connect(node, &StringBuilderNode::patternChanged, edit, updateText);
+
+        updateText();
+
+        return convertToGraphicsWidget(std::move(base), object);
+    };
+}

--- a/src/intelli/gui/ui/node/stringbuildernodeui.h
+++ b/src/intelli/gui/ui/node/stringbuildernodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_STRINGBUILDERNODEUI_H
+#define GT_INTELLI_STRINGBUILDERNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class StringBuilderNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE StringBuilderNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_STRINGBUILDERNODEUI_H

--- a/src/intelli/gui/ui/node/stringinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/stringinputnodeui.cpp
@@ -1,0 +1,50 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/stringinputnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/node/input/stringinput.h>
+
+#include <gt_lineedit.h>
+
+#include <QGraphicsWidget>
+
+using namespace intelli;
+
+StringInputNodeUI::StringInputNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+StringInputNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<StringInputNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<StringInputNode*>(&source);
+        if (!node) return nullptr;
+
+        auto w = std::make_unique<GtLineEdit>();
+        w->setPlaceholderText(QStringLiteral("String"));
+        w->setMinimumWidth(50);
+        w->resize(100, w->sizeHint().height());
+
+        auto const updateProp = [node, w_ = w.get()]() {
+            if (node->value() != w_->text()) node->setValue(w_->text());
+        };
+        auto const updateText = [node, w_ = w.get()]() {
+            if (w_->text() != node->value()) w_->setText(node->value());
+        };
+
+        QObject::connect(w.get(), &GtLineEdit::focusOut, w.get(), updateProp);
+        QObject::connect(w.get(), &GtLineEdit::clearFocusOut, w.get(), updateProp);
+        QObject::connect(node, &StringInputNode::valueChanged, w.get(), updateText);
+
+        updateText();
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/stringinputnodeui.h
+++ b/src/intelli/gui/ui/node/stringinputnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_STRINGINPUTNODEUI_H
+#define GT_INTELLI_STRINGINPUTNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class StringInputNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE StringInputNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_STRINGINPUTNODEUI_H

--- a/src/intelli/gui/ui/node/stringselectionnodeui.cpp
+++ b/src/intelli/gui/ui/node/stringselectionnodeui.cpp
@@ -1,0 +1,58 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/stringselectionnodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/node/stringselection.h>
+
+#include <QComboBox>
+#include <QGraphicsWidget>
+
+using namespace intelli;
+
+StringSelectionNodeUI::StringSelectionNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+StringSelectionNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<StringSelectionNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<StringSelectionNode*>(&source);
+        if (!node) return nullptr;
+
+        auto w = std::make_unique<QComboBox>();
+
+        auto const updateOptions = [w_ = w.get()](QStringList const& options) {
+            w_->clear();
+            w_->addItems(options);
+        };
+        auto const updateSelection = [w_ = w.get()](QString const& selection) {
+            if (selection.isEmpty())
+            {
+                w_->setCurrentIndex(-1);
+                return;
+            }
+            if (w_->currentText() != selection) w_->setCurrentText(selection);
+        };
+
+        QObject::connect(node, &StringSelectionNode::optionsChanged,
+                         w.get(), updateOptions);
+        QObject::connect(node, &StringSelectionNode::selectionChanged,
+                         w.get(), updateSelection);
+        QObject::connect(w.get(), &QComboBox::currentTextChanged,
+                         w.get(), [node](QString const& text) {
+            node->setSelection(text);
+        });
+
+        updateOptions(node->options());
+        updateSelection(node->selection());
+
+        return convertToGraphicsWidget(std::move(w), object);
+    };
+}

--- a/src/intelli/gui/ui/node/stringselectionnodeui.h
+++ b/src/intelli/gui/ui/node/stringselectionnodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_STRINGSELECTIONNODEUI_H
+#define GT_INTELLI_STRINGSELECTIONNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class StringSelectionNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE StringSelectionNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_STRINGSELECTIONNODEUI_H

--- a/src/intelli/gui/ui/node/textdisplaynodeui.cpp
+++ b/src/intelli/gui/ui/node/textdisplaynodeui.cpp
@@ -1,0 +1,89 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#include <intelli/gui/ui/node/textdisplaynodeui.h>
+
+#include <intelli/gui/graphics/nodeobject.h>
+#include <intelli/gui/utilities.h>
+#include <intelli/node/textdisplay.h>
+
+#include <gt_application.h>
+#include <gt_codeeditor.h>
+#include <gt_jshighlighter.h>
+#include <gt_pyhighlighter.h>
+#include <gt_xmlhighlighter.h>
+
+#include <QGraphicsWidget>
+#include <QLayout>
+#include <QSyntaxHighlighter>
+#include <QTextDocument>
+
+#include <cassert>
+
+using namespace intelli;
+
+TextDisplayNodeUI::TextDisplayNodeUI() = default;
+
+NodeUI::WidgetFactoryFunction
+TextDisplayNodeUI::centralWidgetFactory(Node const& n) const
+{
+    if (!qobject_cast<TextDisplayNode const*>(&n)) return {};
+
+    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+        auto* node = qobject_cast<TextDisplayNode*>(&source);
+        if (!node) return nullptr;
+
+        auto b = utils::makeWidgetWithLayout();
+        auto* lay = b->layout();
+
+        auto* w = new GtCodeEditor();
+        lay->addWidget(w);
+
+        w->setMinimumSize(125, 25);
+        w->resize(400, 200);
+        w->setReadOnly(true);
+
+        auto const updateHighlighter = [node, w]() {
+            auto* document = w->document();
+            assert(document);
+
+            auto* highlighter = document->findChild<QSyntaxHighlighter*>();
+            if (highlighter) highlighter->deleteLater();
+
+            switch (node->textType())
+            {
+            case TextDisplayNode::TextType::PlainText:
+                break;
+            case TextDisplayNode::TextType::Xml:
+                new GtXmlHighlighter(document);
+                break;
+            case TextDisplayNode::TextType::Python:
+                new GtPyHighlighter(document);
+                break;
+            case TextDisplayNode::TextType::JavaScript:
+                new GtJsHighlighter(document);
+                break;
+            }
+        };
+
+        auto const updateText = [node, w]() {
+            w->setPlainText(node->displayText());
+        };
+
+        QObject::connect(node, &Node::inputDataRecieved, w, updateText);
+        QObject::connect(node,
+                         qOverload<GtObject*, GtAbstractProperty*>(&Node::dataChanged),
+                         w,
+                         updateHighlighter);
+        QObject::connect(gtApp, &GtApplication::themeChanged, w, updateHighlighter);
+
+        updateText();
+        updateHighlighter();
+
+        return convertToGraphicsWidget(std::move(b), object);
+    };
+}

--- a/src/intelli/gui/ui/node/textdisplaynodeui.h
+++ b/src/intelli/gui/ui/node/textdisplaynodeui.h
@@ -1,0 +1,29 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_TEXTDISPLAYNODEUI_H
+#define GT_INTELLI_TEXTDISPLAYNODEUI_H
+
+#include <intelli/gui/nodeui.h>
+
+namespace intelli
+{
+
+class TextDisplayNodeUI : public NodeUI
+{
+    Q_OBJECT
+
+public:
+
+    Q_INVOKABLE TextDisplayNodeUI();
+
+    WidgetFactoryFunction centralWidgetFactory(Node const& node) const override;
+};
+
+} // namespace intelli
+
+#endif // GT_INTELLI_TEXTDISPLAYNODEUI_H

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -32,6 +32,7 @@
 #include "intelli/node/objectsink.h"
 #include "intelli/node/stringbuilder.h"
 #include "intelli/node/stringselection.h"
+#include "intelli/node/sleepy.h"
 #include "intelli/node/textdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
@@ -58,6 +59,7 @@
 #include "intelli/gui/ui/node/objectsinknodeui.h"
 #include "intelli/gui/ui/node/stringbuildernodeui.h"
 #include "intelli/gui/ui/node/stringselectionnodeui.h"
+#include "intelli/gui/ui/node/sleepynodeui.h"
 #include "intelli/gui/ui/node/textdisplaynodeui.h"
 #include "intelli/gui/ui/node/fileinputnodeui.h"
 #include "intelli/gui/ui/node/doubleinputnodeui.h"
@@ -348,6 +350,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(StringBuilderNodeUI));
     map.insert(GT_CLASSNAME(StringSelectionNode),
                GT_METADATA(StringSelectionNodeUI));
+    map.insert(GT_CLASSNAME(SleepyNode),
+               GT_METADATA(SleepyNodeUI));
 
     QStringList registeredNodes = NodeFactory::instance().registeredNodes();
 

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -27,6 +27,7 @@
 #include "intelli/node/booldisplay.h"
 #include "intelli/node/logicoperation.h"
 #include "intelli/node/numberdisplay.h"
+#include "intelli/node/numbermath.h"
 #include "intelli/node/textdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
@@ -44,6 +45,7 @@
 #include "intelli/gui/ui/node/boolnodeui.h"
 #include "intelli/gui/ui/node/logicnodeui.h"
 #include "intelli/gui/ui/node/numberdisplaynodeui.h"
+#include "intelli/gui/ui/node/numbermathnodeui.h"
 #include "intelli/gui/ui/node/textdisplaynodeui.h"
 #include "intelli/gui/ui/node/fileinputnodeui.h"
 #include "intelli/gui/property_item/stringselection.h"
@@ -303,6 +305,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(LogicNodeUI));
     map.insert(GT_CLASSNAME(NumberDisplayNode),
                GT_METADATA(NumberDisplayNodeUI));
+    map.insert(GT_CLASSNAME(NumberMathNode),
+               GT_METADATA(NumberMathNodeUI));
     map.insert(GT_CLASSNAME(TextDisplayNode),
                GT_METADATA(TextDisplayNodeUI));
 

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -26,6 +26,7 @@
 #include "intelli/node/binarydisplay.h"
 #include "intelli/node/booldisplay.h"
 #include "intelli/node/existingdirectorysource.h"
+#include "intelli/node/finddirectchild.h"
 #include "intelli/node/logicoperation.h"
 #include "intelli/node/numberdisplay.h"
 #include "intelli/node/numbermath.h"
@@ -53,6 +54,7 @@
 #include "intelli/gui/ui/packageui.h"
 #include "intelli/gui/ui/node/boolnodeui.h"
 #include "intelli/gui/ui/node/existingdirectorysourcenodeui.h"
+#include "intelli/gui/ui/node/finddirectchildnodeui.h"
 #include "intelli/gui/ui/node/logicnodeui.h"
 #include "intelli/gui/ui/node/numberdisplaynodeui.h"
 #include "intelli/gui/ui/node/numbermathnodeui.h"
@@ -344,6 +346,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(IntInputNodeUI));
     map.insert(GT_CLASSNAME(ExistingDirectorySourceNode),
                GT_METADATA(ExistingDirectorySourceNodeUI));
+    map.insert(GT_CLASSNAME(FindDirectChildNode),
+               GT_METADATA(FindDirectChildNodeUI));
     map.insert(GT_CLASSNAME(ObjectSink),
                GT_METADATA(ObjectSinkNodeUI));
     map.insert(GT_CLASSNAME(StringBuilderNode),

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -31,6 +31,7 @@
 #include "intelli/node/numbermath.h"
 #include "intelli/node/objectsink.h"
 #include "intelli/node/stringbuilder.h"
+#include "intelli/node/stringselection.h"
 #include "intelli/node/textdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
@@ -52,6 +53,7 @@
 #include "intelli/gui/ui/node/numbermathnodeui.h"
 #include "intelli/gui/ui/node/objectsinknodeui.h"
 #include "intelli/gui/ui/node/stringbuildernodeui.h"
+#include "intelli/gui/ui/node/stringselectionnodeui.h"
 #include "intelli/gui/ui/node/textdisplaynodeui.h"
 #include "intelli/gui/ui/node/fileinputnodeui.h"
 #include "intelli/gui/property_item/stringselection.h"
@@ -328,8 +330,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(ObjectSinkNodeUI));
     map.insert(GT_CLASSNAME(StringBuilderNode),
                GT_METADATA(StringBuilderNodeUI));
-    map.insert(GT_CLASSNAME(StringBuilderNode),
-               GT_METADATA(StringBuilderNodeUI));
+    map.insert(GT_CLASSNAME(StringSelectionNode),
+               GT_METADATA(StringSelectionNodeUI));
 
     QStringList registeredNodes = NodeFactory::instance().registeredNodes();
 

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -27,6 +27,7 @@
 #include "intelli/node/booldisplay.h"
 #include "intelli/node/existingdirectorysource.h"
 #include "intelli/node/finddirectchild.h"
+#include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/logicoperation.h"
 #include "intelli/node/numberdisplay.h"
 #include "intelli/node/numbermath.h"
@@ -55,6 +56,7 @@
 #include "intelli/gui/ui/node/boolnodeui.h"
 #include "intelli/gui/ui/node/existingdirectorysourcenodeui.h"
 #include "intelli/gui/ui/node/finddirectchildnodeui.h"
+#include "intelli/gui/ui/node/genericcalculatorexecnodeui.h"
 #include "intelli/gui/ui/node/logicnodeui.h"
 #include "intelli/gui/ui/node/numberdisplaynodeui.h"
 #include "intelli/gui/ui/node/numbermathnodeui.h"
@@ -348,6 +350,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(ExistingDirectorySourceNodeUI));
     map.insert(GT_CLASSNAME(FindDirectChildNode),
                GT_METADATA(FindDirectChildNodeUI));
+    map.insert(GT_CLASSNAME(GenericCalculatorExecNode),
+               GT_METADATA(GenericCalculatorExecNodeUI));
     map.insert(GT_CLASSNAME(ObjectSink),
                GT_METADATA(ObjectSinkNodeUI));
     map.insert(GT_CLASSNAME(StringBuilderNode),

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -30,6 +30,7 @@
 #include "intelli/node/numberdisplay.h"
 #include "intelli/node/numbermath.h"
 #include "intelli/node/objectsink.h"
+#include "intelli/node/stringbuilder.h"
 #include "intelli/node/textdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
@@ -50,6 +51,7 @@
 #include "intelli/gui/ui/node/numberdisplaynodeui.h"
 #include "intelli/gui/ui/node/numbermathnodeui.h"
 #include "intelli/gui/ui/node/objectsinknodeui.h"
+#include "intelli/gui/ui/node/stringbuildernodeui.h"
 #include "intelli/gui/ui/node/textdisplaynodeui.h"
 #include "intelli/gui/ui/node/fileinputnodeui.h"
 #include "intelli/gui/property_item/stringselection.h"
@@ -324,6 +326,10 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(ExistingDirectorySourceNodeUI));
     map.insert(GT_CLASSNAME(ObjectSink),
                GT_METADATA(ObjectSinkNodeUI));
+    map.insert(GT_CLASSNAME(StringBuilderNode),
+               GT_METADATA(StringBuilderNodeUI));
+    map.insert(GT_CLASSNAME(StringBuilderNode),
+               GT_METADATA(StringBuilderNodeUI));
 
     QStringList registeredNodes = NodeFactory::instance().registeredNodes();
 

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -27,6 +27,7 @@
 #include "intelli/node/booldisplay.h"
 #include "intelli/node/logicoperation.h"
 #include "intelli/node/numberdisplay.h"
+#include "intelli/node/textdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
 #include "intelli/gui/commentgroup.h"
@@ -42,6 +43,7 @@
 #include "intelli/gui/ui/node/boolnodeui.h"
 #include "intelli/gui/ui/node/logicnodeui.h"
 #include "intelli/gui/ui/node/numberdisplaynodeui.h"
+#include "intelli/gui/ui/node/textdisplaynodeui.h"
 #include "intelli/gui/property_item/stringselection.h"
 
 #include "intelli/calculators/graphexeccalculator.h"
@@ -299,6 +301,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(LogicNodeUI));
     map.insert(GT_CLASSNAME(NumberDisplayNode),
                GT_METADATA(NumberDisplayNodeUI));
+    map.insert(GT_CLASSNAME(TextDisplayNode),
+               GT_METADATA(TextDisplayNodeUI));
 
     map.insert(GT_CLASSNAME(BoolDisplayNode),
                GT_METADATA(BoolNodeUI));

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -26,6 +26,7 @@
 #include "intelli/node/binarydisplay.h"
 #include "intelli/node/booldisplay.h"
 #include "intelli/node/logicoperation.h"
+#include "intelli/node/numberdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
 #include "intelli/gui/commentgroup.h"
@@ -40,6 +41,7 @@
 #include "intelli/gui/ui/packageui.h"
 #include "intelli/gui/ui/node/boolnodeui.h"
 #include "intelli/gui/ui/node/logicnodeui.h"
+#include "intelli/gui/ui/node/numberdisplaynodeui.h"
 #include "intelli/gui/property_item/stringselection.h"
 
 #include "intelli/calculators/graphexeccalculator.h"
@@ -295,6 +297,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(LogicNodeUI));
     map.insert(GT_CLASSNAME(BinaryDisplayNode),
                GT_METADATA(LogicNodeUI));
+    map.insert(GT_CLASSNAME(NumberDisplayNode),
+               GT_METADATA(NumberDisplayNodeUI));
 
     map.insert(GT_CLASSNAME(BoolDisplayNode),
                GT_METADATA(BoolNodeUI));

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -25,6 +25,7 @@
 #include "intelli/property/stringselection.h"
 #include "intelli/node/binarydisplay.h"
 #include "intelli/node/booldisplay.h"
+#include "intelli/node/existingdirectorysource.h"
 #include "intelli/node/logicoperation.h"
 #include "intelli/node/numberdisplay.h"
 #include "intelli/node/numbermath.h"
@@ -43,6 +44,7 @@
 #include "intelli/gui/ui/guidataui.h"
 #include "intelli/gui/ui/packageui.h"
 #include "intelli/gui/ui/node/boolnodeui.h"
+#include "intelli/gui/ui/node/existingdirectorysourcenodeui.h"
 #include "intelli/gui/ui/node/logicnodeui.h"
 #include "intelli/gui/ui/node/numberdisplaynodeui.h"
 #include "intelli/gui/ui/node/numbermathnodeui.h"
@@ -316,6 +318,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(BoolNodeUI));
     map.insert(GT_CLASSNAME(FileInputNode),
                GT_METADATA(FileInputNodeUI));
+    map.insert(GT_CLASSNAME(ExistingDirectorySourceNode),
+               GT_METADATA(ExistingDirectorySourceNodeUI));
 
     QStringList registeredNodes = NodeFactory::instance().registeredNodes();
 

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -29,6 +29,7 @@
 #include "intelli/node/logicoperation.h"
 #include "intelli/node/numberdisplay.h"
 #include "intelli/node/numbermath.h"
+#include "intelli/node/objectsink.h"
 #include "intelli/node/textdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
@@ -48,6 +49,7 @@
 #include "intelli/gui/ui/node/logicnodeui.h"
 #include "intelli/gui/ui/node/numberdisplaynodeui.h"
 #include "intelli/gui/ui/node/numbermathnodeui.h"
+#include "intelli/gui/ui/node/objectsinknodeui.h"
 #include "intelli/gui/ui/node/textdisplaynodeui.h"
 #include "intelli/gui/ui/node/fileinputnodeui.h"
 #include "intelli/gui/property_item/stringselection.h"
@@ -320,6 +322,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(FileInputNodeUI));
     map.insert(GT_CLASSNAME(ExistingDirectorySourceNode),
                GT_METADATA(ExistingDirectorySourceNodeUI));
+    map.insert(GT_CLASSNAME(ObjectSink),
+               GT_METADATA(ObjectSinkNodeUI));
 
     QStringList registeredNodes = NodeFactory::instance().registeredNodes();
 

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -35,7 +35,11 @@
 #include "intelli/node/textdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
+#include "intelli/node/input/doubleinput.h"
 #include "intelli/node/input/fileinput.h"
+#include "intelli/node/input/intinput.h"
+#include "intelli/node/input/objectinput.h"
+#include "intelli/node/input/stringinput.h"
 #include "intelli/gui/commentgroup.h"
 #include "intelli/gui/commentdata.h"
 #include "intelli/gui/grapheditor.h"
@@ -56,6 +60,10 @@
 #include "intelli/gui/ui/node/stringselectionnodeui.h"
 #include "intelli/gui/ui/node/textdisplaynodeui.h"
 #include "intelli/gui/ui/node/fileinputnodeui.h"
+#include "intelli/gui/ui/node/doubleinputnodeui.h"
+#include "intelli/gui/ui/node/intinputnodeui.h"
+#include "intelli/gui/ui/node/objectinputnodeui.h"
+#include "intelli/gui/ui/node/stringinputnodeui.h"
 #include "intelli/gui/property_item/stringselection.h"
 
 #include "intelli/calculators/graphexeccalculator.h"
@@ -324,6 +332,14 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(BoolNodeUI));
     map.insert(GT_CLASSNAME(FileInputNode),
                GT_METADATA(FileInputNodeUI));
+    map.insert(GT_CLASSNAME(ObjectInputNode),
+               GT_METADATA(ObjectInputNodeUI));
+    map.insert(GT_CLASSNAME(StringInputNode),
+               GT_METADATA(StringInputNodeUI));
+    map.insert(GT_CLASSNAME(DoubleInputNode),
+               GT_METADATA(DoubleInputNodeUI));
+    map.insert(GT_CLASSNAME(IntInputNode),
+               GT_METADATA(IntInputNodeUI));
     map.insert(GT_CLASSNAME(ExistingDirectorySourceNode),
                GT_METADATA(ExistingDirectorySourceNodeUI));
     map.insert(GT_CLASSNAME(ObjectSink),

--- a/src/intelli/module.cpp
+++ b/src/intelli/module.cpp
@@ -30,6 +30,7 @@
 #include "intelli/node/textdisplay.h"
 #include "intelli/node/genericcalculatorexec.h"
 #include "intelli/node/input/boolinput.h"
+#include "intelli/node/input/fileinput.h"
 #include "intelli/gui/commentgroup.h"
 #include "intelli/gui/commentdata.h"
 #include "intelli/gui/grapheditor.h"
@@ -44,6 +45,7 @@
 #include "intelli/gui/ui/node/logicnodeui.h"
 #include "intelli/gui/ui/node/numberdisplaynodeui.h"
 #include "intelli/gui/ui/node/textdisplaynodeui.h"
+#include "intelli/gui/ui/node/fileinputnodeui.h"
 #include "intelli/gui/property_item/stringselection.h"
 
 #include "intelli/calculators/graphexeccalculator.h"
@@ -308,6 +310,8 @@ GtIntelliGraphModule::uiItems()
                GT_METADATA(BoolNodeUI));
     map.insert(GT_CLASSNAME(BoolInputNode),
                GT_METADATA(BoolNodeUI));
+    map.insert(GT_CLASSNAME(FileInputNode),
+               GT_METADATA(FileInputNodeUI));
 
     QStringList registeredNodes = NodeFactory::instance().registeredNodes();
 

--- a/src/intelli/node.cpp
+++ b/src/intelli/node.cpp
@@ -536,9 +536,9 @@ Node::registerWidgetFactory(WidgetFactory factory)
 void
 Node::registerWidgetFactory(WidgetFactoryNoArgs factory)
 {
-    registerWidgetFactory([f = std::move(factory)](Node&){
+    pimpl->widgetFactory = [f = std::move(factory)](Node&){
         return f();
-    });
+    };
 }
 
 //////////////////////////////////////////////////////

--- a/src/intelli/node.h
+++ b/src/intelli/node.h
@@ -198,9 +198,9 @@ public:
 
     /// widget factory function type. Parameter is guranteed to be of type
     /// "this" and can be casted safely using static_cast.
-    using WidgetFactory [[deprecated]] =
+    using WidgetFactory =
         std::function<std::unique_ptr<QWidget>(Node& thisNode)>;
-    using WidgetFactoryNoArgs [[deprecated]] =
+    using WidgetFactoryNoArgs =
         std::function<std::unique_ptr<QWidget>()>;
 
     /// Enums inidacting of node event

--- a/src/intelli/node/existingdirectorysource.cpp
+++ b/src/intelli/node/existingdirectorysource.cpp
@@ -11,7 +11,7 @@
 #include "intelli/data/string.h"
 #include "intelli/nodedata.h"
 
-#include <gt_propertyfilechoosereditor.h>
+#include <gt_abstractproperty.h>
 
 using namespace intelli;
 
@@ -28,14 +28,23 @@ ExistingDirectorySourceNode::ExistingDirectorySourceNode():
 
     connect(&m_value, &GtAbstractProperty::changed,
             this, &Node::triggerNodeEvaluation);
+    connect(&m_value, &GtAbstractProperty::changed,
+            this, [this]() { emit directoryChanged(m_value.get()); });
 
-    registerWidgetFactory([=](){
-        auto w = std::make_unique<GtPropertyFileChooserEditor>();
-        w->setMinimumWidth(120);
-        w->setFileChooserProperty(&m_value);
+    emit directoryChanged(m_value.get());
+}
 
-        return w;
-    });
+QString
+ExistingDirectorySourceNode::directory() const
+{
+    return m_value.get();
+}
+
+void
+ExistingDirectorySourceNode::setDirectory(QString const& path)
+{
+    if (m_value.get() == path) return;
+    m_value.setVal(path);
 }
 
 void

--- a/src/intelli/node/existingdirectorysource.h
+++ b/src/intelli/node/existingdirectorysource.h
@@ -22,6 +22,15 @@ class ExistingDirectorySourceNode : public Node
 public:
     Q_INVOKABLE ExistingDirectorySourceNode();
 
+    QString directory() const;
+    void setDirectory(QString const& path);
+
+signals:
+
+    void directoryChanged(QString const& path);
+
+protected:
+
     void eval() override;
 
 private:

--- a/src/intelli/node/filewriter.cpp
+++ b/src/intelli/node/filewriter.cpp
@@ -20,7 +20,7 @@ using namespace intelli;
 FileWriterNode::FileWriterNode() :
     Node("File Writer")
 {
-    setNodeEvalMode(NodeEvalMode::Exclusive);
+    setNodeEvalMode(NodeEvalMode::ExclusiveDetached);
 
     m_inFile = addInPort({typeId<FileData>(), tr("file")}, Required);
     m_inData = addInPort({typeId<ByteArrayData>(), tr("data")}, Required);

--- a/src/intelli/node/finddirectchild.cpp
+++ b/src/intelli/node/finddirectchild.cpp
@@ -11,13 +11,6 @@
 
 #include "intelli/data/object.h"
 
-#include "intelli/gui/widgets/finddirectchildwidget.h"
-
-#include <gt_lineedit.h>
-
-#include <QRegExpValidator>
-#include <QRegExp>
-
 using namespace intelli;
 
 FindDirectChildNode::FindDirectChildNode() :
@@ -37,40 +30,47 @@ FindDirectChildNode::FindDirectChildNode() :
     m_in = addInPort(typeId<ObjectData>());
     m_out = addOutPort(makePort(typeId<ObjectData>()).setCaption(tr("child")));
 
-    registerWidgetFactory([this]() {
-        auto w = std::make_unique<FindDirectChildWidget>();
-
-        w->updateNameCompleter(nodeData<ObjectData>(m_in).get());
-        
-        connect(w.get(), &FindDirectChildWidget::updateClass,
-                this, [this](QString const& newClass) {
-            m_targetClassName.setVal(newClass);
-        });
-        connect(&m_targetClassName, SIGNAL(changed()),
-                w.get(), SLOT(updateClassText()));
-        
-        connect(w.get(), &FindDirectChildWidget::updateObjectName,
-                this, [this](QString const& newObjName) {
-            m_targetObjectName.setVal(newObjName);
-        });
-        connect(&m_targetObjectName, SIGNAL(changed()),
-                w.get(), SLOT(updateNameText()));
-
-        connect(this, &Node::inputDataRecieved,
-                w.get(), [this, wid = w.get()]() {
-            wid->updateNameCompleter(nodeData<ObjectData>(m_in).get());
-        });
-
-        w->setClassNameWidget(m_targetClassName.getVal());
-        w->setObjectNameWidget(m_targetObjectName.getVal());
-
-        return w;
-    });
-
     connect(&m_targetClassName, &GtAbstractProperty::changed,
             this, &Node::triggerNodeEvaluation);
     connect(&m_targetObjectName, &GtAbstractProperty::changed,
             this, &Node::triggerNodeEvaluation);
+
+    connect(&m_targetClassName, &GtAbstractProperty::changed,
+            this, [this]() { emit targetClassNameChanged(m_targetClassName.get()); });
+    connect(&m_targetObjectName, &GtAbstractProperty::changed,
+            this, [this]() { emit targetObjectNameChanged(m_targetObjectName.get()); });
+}
+
+QString
+FindDirectChildNode::targetClassName() const
+{
+    return m_targetClassName.get();
+}
+
+void
+FindDirectChildNode::setTargetClassName(QString const& name)
+{
+    if (m_targetClassName.get() == name) return;
+    m_targetClassName.setVal(name);
+}
+
+QString
+FindDirectChildNode::targetObjectName() const
+{
+    return m_targetObjectName.get();
+}
+
+void
+FindDirectChildNode::setTargetObjectName(QString const& name)
+{
+    if (m_targetObjectName.get() == name) return;
+    m_targetObjectName.setVal(name);
+}
+
+ObjectData const*
+FindDirectChildNode::inputObject() const
+{
+    return nodeData<ObjectData>(m_in).get();
 }
 
 void

--- a/src/intelli/node/finddirectchild.h
+++ b/src/intelli/node/finddirectchild.h
@@ -36,6 +36,17 @@ public:
 
     Q_INVOKABLE FindDirectChildNode();
 
+    QString targetClassName() const;
+    void setTargetClassName(QString const& name);
+    QString targetObjectName() const;
+    void setTargetObjectName(QString const& name);
+    ObjectData const* inputObject() const;
+
+signals:
+
+    void targetClassNameChanged(QString const& name);
+    void targetObjectNameChanged(QString const& name);
+
 protected:
 
     void eval() override;

--- a/src/intelli/node/genericcalculatorexec.cpp
+++ b/src/intelli/node/genericcalculatorexec.cpp
@@ -312,76 +312,56 @@ GenericCalculatorExecNode::GenericCalculatorExecNode() :
     connect(this, &Node::portDisconnected, this,
             &GenericCalculatorExecNode::onPortDisconnected);
 
-     registerWidgetFactory([this]() {
-        auto w = std::make_unique<QWidget>();
-        auto* lay = new QVBoxLayout;
-        w->setLayout(lay);
-        lay->setContentsMargins(0, 0, 0, 0);
-
-        auto* edit = new QComboBox;
-        edit->addItems(Impl::classIndents());
-        edit->setStyleSheet(gt::gui::stylesheet::comboBox());
-
-        lay->addWidget(edit);
-
-        auto* model = exec::nodeDataInterface(*this);
-        GtObject* scope = model ? model->scope() : gtApp->currentProject();
-        assert(scope);
-
-        auto* view = new GtPropertyTreeView(scope);
-        view->setAnimated(false);
-        lay->addWidget(view);
-
-        auto updateView = [view, this](){
-            view->setObject(nullptr);
-
-            auto obj = this->currentObject();
-            if (obj)
-            {
-                view->setObject(obj);
-                // collapse first category
-                view->collapse(view->model()->index(0, 0, view->rootIndex()));
-
-                connect(obj, qOverload<GtObject*, GtAbstractProperty*>(&GtObject::dataChanged),
-                        this, &GenericCalculatorExecNode::onCurrentObjectDataChanged,
-                        Qt::UniqueConnection);
-            }
-        };
-
-        auto const updateClass = [this, edit](){
-            m_className = Impl::identToClassName(edit->currentText());
-        };
-        auto const updateClassText = [this, edit](){
-            edit->setCurrentText(Impl::classNameToIdent(m_className));
-        };
-
-        connect(edit, &QComboBox::currentTextChanged,
-                this, updateClass);
-        connect(&m_className, &GtAbstractProperty::changed,
-                edit, updateClassText);
-        connect(this, &GenericCalculatorExecNode::currentObjectChanged,
-                view, updateView);
-
-        /// iterate over ports to remove already connected ones at start
-        for (auto* ports : {&m_calcInPorts, &m_calcOutPorts})
-        {
-            gt::for_each_key(ports->begin(), ports->end(),
-                             [this](PortId portId){
-                if (nodeData<NodeData const>(portId))
-                {
-                    onPortConnected(portId);
-                }
-            });
-        }
-
-        m_className.get().isEmpty() ? updateClass() : updateClassText();
-        updateView();
-
-        return w;
-    });
-
     connect(&m_className, &GtAbstractProperty::changed,
             this, &GenericCalculatorExecNode::updateCurrentObject);
+    connect(&m_className, &GtAbstractProperty::changed,
+            this, [this]() { emit classNameChanged(m_className.get()); });
+}
+
+QString
+GenericCalculatorExecNode::className() const
+{
+    return m_className.get();
+}
+
+void
+GenericCalculatorExecNode::setClassName(QString const& className)
+{
+    if (m_className.get() == className) return;
+    m_className.setVal(className);
+}
+
+QStringList
+GenericCalculatorExecNode::classIdents()
+{
+    return Impl::classIndents();
+}
+
+QString
+GenericCalculatorExecNode::classNameFromIdent(QString const& ident)
+{
+    return Impl::identToClassName(ident);
+}
+
+QString
+GenericCalculatorExecNode::identFromClassName(QString const& className)
+{
+    return Impl::classNameToIdent(className);
+}
+
+void
+GenericCalculatorExecNode::syncConnectedPorts()
+{
+    for (auto* ports : {&m_calcInPorts, &m_calcOutPorts})
+    {
+        gt::for_each_key(ports->begin(), ports->end(),
+                         [this](PortId portId){
+            if (nodeData<NodeData const>(portId))
+            {
+                onPortConnected(portId);
+            }
+        });
+    }
 }
 
 void

--- a/src/intelli/node/genericcalculatorexec.h
+++ b/src/intelli/node/genericcalculatorexec.h
@@ -26,6 +26,17 @@ public:
 
     Q_INVOKABLE GenericCalculatorExecNode();
 
+    QString className() const;
+    void setClassName(QString const& className);
+    static QStringList classIdents();
+    static QString classNameFromIdent(QString const& ident);
+    static QString identFromClassName(QString const& className);
+
+    /// returns the current child object
+    GtObject* currentObject();
+
+    void syncConnectedPorts();
+
     /**
      * @brief Static member function that allows other modules to append class
      * names of calculators to the internal whitelist. Only whitelisted
@@ -43,7 +54,11 @@ private slots:
 
     void updateCurrentObject();
 
+public slots:
+
     void onCurrentObjectDataChanged();
+
+private slots:
 
     void onPortConnected(PortId portId);
 
@@ -53,6 +68,7 @@ signals:
 
     /// signals that the current object/calculator changed
     void currentObjectChanged();
+    void classNameChanged(QString const& className);
 
 private:
 
@@ -67,9 +83,6 @@ private:
     QHash<PortId, QString> m_calcInPorts;
     /// dynamic output ports for the output data of the calculator
     QHash<PortId, QString> m_calcOutPorts;
-
-    /// returns the current child objet
-    GtObject* currentObject();
 
     /// init the input ports based on the properties
     void initPorts();

--- a/src/intelli/node/input/doubleinput.cpp
+++ b/src/intelli/node/input/doubleinput.cpp
@@ -12,6 +12,8 @@
 
 #include <intelli/gui/widgets/doubleinputwidget.h>
 
+#include <QString>
+
 using namespace intelli;
 
 DoubleInputNode::DoubleInputNode() :
@@ -37,80 +39,46 @@ DoubleInputNode::DoubleInputNode() :
     setNodeFlag(Resizable);
     setNodeEvalMode(NodeEvalMode::Blocking);
 
-    registerWidgetFactory([this]() {
+    bool success = m_inputMode.registerEnum<DoubleInputWidget::InputMode>();
+    assert(success);
+
+    auto updateResizability = [this]() {
         using InputMode = DoubleInputWidget::InputMode;
+        switch (static_cast<InputMode>(inputModeValue()))
+        {
+        case InputMode::SliderH:
+        case InputMode::LineEditBound:
+        case InputMode::LineEditUnbound:
+            setNodeFlag(ResizableHOnly, true);
+            break;
+        default:
+            setNodeFlag(ResizableHOnly, false);
+            break;
+        }
+    };
 
-        bool success = m_inputMode.registerEnum<InputMode>();
-        assert(success);
-
-        auto mode = m_inputMode.getEnum<InputMode>();
-
-        auto w = new DoubleInputWidget(mode);
-
-        auto onRangeChanged = [this, w](){
-            w->setRange(value(), lowerBound(), upperBound());
-            emit nodeChanged();
-            emit triggerNodeEvaluation();
-        };
-
-        auto onMinChanged = [=](){
-            double newVal = w->min();
-            if (lowerBound() != newVal) setLowerBound(newVal);
-        };
-
-        auto onMaxChanged = [=](){
-            double newVal = w->max();
-            if (upperBound() != newVal) setUpperBound(newVal);
-        };
-
-        auto onValueChanged = [=](){
-            double newVal = w->value();
-            if (value() != newVal)
-            {
-                setValue(newVal);
+    connect(&m_value, &GtDoubleProperty::changed,
+            this, [this]() { emit rangeChanged(); });
+    connect(&m_min, &GtDoubleProperty::changed,
+            this, [this]() {
+                emit rangeChanged();
+                emit nodeChanged();
                 emit triggerNodeEvaluation();
-            }
-        };
+            });
+    connect(&m_max, &GtDoubleProperty::changed,
+            this, [this]() {
+                emit rangeChanged();
+                emit nodeChanged();
+                emit triggerNodeEvaluation();
+            });
+    connect(&m_inputMode, &GtAbstractProperty::changed,
+            this, [this, updateResizability]() {
+                updateResizability();
+                emit inputModeChanged();
+                emit nodeChanged();
+            });
 
-        auto const updateMode= [this, w]() {
-            w->setInputMode(m_inputMode.getEnum<InputMode>());
-
-            setUseBounds(w->useBounds());
-
-            switch (w->inputMode())
-            {
-            case InputMode::SliderH:
-            case InputMode::LineEditBound:
-            case InputMode::LineEditUnbound:
-                setNodeFlag(ResizableHOnly, true);
-                break;
-            default:
-                setNodeFlag(ResizableHOnly, false);
-                break;
-            }
-
-            emit nodeChanged();
-        };
-
-        connect(w, &DoubleInputWidget::valueComitted,
-                this, onValueChanged);
-        connect(w, &DoubleInputWidget::minChanged,
-                this, onMinChanged);
-        connect(w, &DoubleInputWidget::maxChanged,
-                this, onMaxChanged);
-
-        connect(&m_min, &GtDoubleProperty::changed,
-                w, onRangeChanged);
-        connect(&m_max, &GtDoubleProperty::changed,
-                w, onRangeChanged);
-        connect(&m_inputMode, &GtAbstractProperty::changed,
-                w, updateMode);
-
-        onRangeChanged();
-        updateMode();
-
-        return std::unique_ptr<QWidget>(w);
-    });
+    updateResizability();
 }
 
 double
@@ -166,9 +134,26 @@ DoubleInputNode::setUseBounds(bool value)
     if (m_useBounds != value) m_useBounds = value;
 }
 
+int
+DoubleInputNode::inputModeValue() const
+{
+    if (!m_inputMode.isInitialized()) return 0;
+    return m_inputMode.getMetaEnum().keyToValue(m_inputMode.getVal().toUtf8());
+}
+
+void
+DoubleInputNode::setInputModeValue(int value)
+{
+    if (!m_inputMode.isInitialized()) return;
+    const char* key = m_inputMode.getMetaEnum().valueToKey(value);
+    if (!key) return;
+    if (m_inputMode.getVal() == QLatin1String(key)) return;
+    bool success = true;
+    m_inputMode.setVal(key, &success);
+}
+
 void
 DoubleInputNode::eval()
 {
     setNodeData(m_out, std::make_shared<DoubleData>(value()));
 }
-

--- a/src/intelli/node/input/doubleinput.cpp
+++ b/src/intelli/node/input/doubleinput.cpp
@@ -11,8 +11,7 @@
 #include <intelli/data/double.h>
 
 #include <intelli/gui/widgets/doubleinputwidget.h>
-
-#include <QString>
+#include <intelli/node/input/numberinputnode_utils.h>
 
 using namespace intelli;
 
@@ -39,46 +38,13 @@ DoubleInputNode::DoubleInputNode() :
     setNodeFlag(Resizable);
     setNodeEvalMode(NodeEvalMode::Blocking);
 
-    bool success = m_inputMode.registerEnum<DoubleInputWidget::InputMode>();
-    assert(success);
-
-    auto updateResizability = [this]() {
-        using InputMode = DoubleInputWidget::InputMode;
-        switch (static_cast<InputMode>(inputModeValue()))
-        {
-        case InputMode::SliderH:
-        case InputMode::LineEditBound:
-        case InputMode::LineEditUnbound:
-            setNodeFlag(ResizableHOnly, true);
-            break;
-        default:
-            setNodeFlag(ResizableHOnly, false);
-            break;
-        }
-    };
-
-    connect(&m_value, &GtDoubleProperty::changed,
-            this, [this]() { emit rangeChanged(); });
-    connect(&m_min, &GtDoubleProperty::changed,
-            this, [this]() {
-                emit rangeChanged();
-                emit nodeChanged();
-                emit triggerNodeEvaluation();
-            });
-    connect(&m_max, &GtDoubleProperty::changed,
-            this, [this]() {
-                emit rangeChanged();
-                emit nodeChanged();
-                emit triggerNodeEvaluation();
-            });
-    connect(&m_inputMode, &GtAbstractProperty::changed,
-            this, [this, updateResizability]() {
-                updateResizability();
-                emit inputModeChanged();
-                emit nodeChanged();
-            });
-
-    updateResizability();
+    detail::setupNumberInputNode<DoubleInputNode,
+                                 GtDoubleProperty,
+                                 GtDoubleProperty,
+                                 MetaEnumProperty,
+                                 DoubleInputWidget::InputMode>(
+        this, m_value, m_min, m_max, m_inputMode,
+        [this](bool enable) { setNodeFlag(ResizableHOnly, enable); });
 }
 
 double
@@ -137,19 +103,13 @@ DoubleInputNode::setUseBounds(bool value)
 int
 DoubleInputNode::inputModeValue() const
 {
-    if (!m_inputMode.isInitialized()) return 0;
-    return m_inputMode.getMetaEnum().keyToValue(m_inputMode.getVal().toUtf8());
+    return detail::inputModeValue(m_inputMode);
 }
 
 void
 DoubleInputNode::setInputModeValue(int value)
 {
-    if (!m_inputMode.isInitialized()) return;
-    const char* key = m_inputMode.getMetaEnum().valueToKey(value);
-    if (!key) return;
-    if (m_inputMode.getVal() == QLatin1String(key)) return;
-    bool success = true;
-    m_inputMode.setVal(key, &success);
+    detail::setInputModeValue(m_inputMode, value);
 }
 
 void

--- a/src/intelli/node/input/doubleinput.h
+++ b/src/intelli/node/input/doubleinput.h
@@ -42,6 +42,14 @@ public:
     bool useBounds() const;
     void setUseBounds(bool value);
 
+    int inputModeValue() const;
+    void setInputModeValue(int value);
+
+signals:
+
+    void rangeChanged();
+    void inputModeChanged();
+
 protected:
 
     void eval() override;

--- a/src/intelli/node/input/fileinput.cpp
+++ b/src/intelli/node/input/fileinput.cpp
@@ -13,13 +13,8 @@
 #include <intelli/data/file.h>
 
 #include <gt_coreapplication.h>
-#include <gt_propertyfilechoosereditor.h>
-#include <gt_filedialog.h>
 
 #include <QDir>
-#include <QLayout>
-#include <QPushButton>
-#include <QFileDialog>
 
 using namespace intelli;
 
@@ -35,80 +30,63 @@ FileInputNode::FileInputNode() :
     m_inName = addInPort({typeId<StringData>(), tr("file_name")});
     m_outFile = addOutPort({typeId<FileData>(), tr("file")});
 
-    registerWidgetFactory([this](){
-        auto b = makeBaseWidget();
-        auto* lay = b->layout();
-
-        auto w = new GtPropertyFileChooserEditor();
-        lay->addWidget(w);
-
-        w->setMinimumWidth(150);
-        w->setFileChooserProperty(&m_fileChooser);
-
-        // show/hide widget if "name" port is connected
-        auto updateWidget = [this, w, b_ = b.get()](PortId portId, bool connected){
-            if (portId == m_inName)
-            {
-                w->setVisible(!connected);
-                setNodeFlag(ResizableHOnly, !connected);
-
-                b_->setMinimumWidth(connected ? 10 : w->minimumWidth());
-                b_->resize(b_->minimumSize());
-
-                emit nodeChanged();
-            }
-        };
-
-        auto showWidget = [updateWidget](PortId portId){
-            updateWidget(portId, false);
-        };
-        auto hideWidget = [updateWidget](PortId portId){
-            updateWidget(portId, true);
-        };
-
-        updateWidget(m_inName, port(m_inName)->isConnected());
-
-        connect(this, &Node::portConnected, w, hideWidget);
-        connect(this, &Node::portDisconnected, w, showWidget);
-
-        // override functionality of select file path push button
-        auto const& btns = w->findChildren<QPushButton*>();
-        if (btns.empty()) return b;
-
-        auto* btn = btns.last();
-        if (!btn) return b;
-
-        btn->disconnect();
-
-        connect(btn, &QPushButton::clicked, this, [this, b_ = b.get()](){
-            QString dir;
-            if (auto const& dirData = nodeData<StringData>(m_inDir))
-            {
-                dir = dirData->value();
-            }
-
-            QString const& fileName =
-                QFileDialog::getOpenFileName(b_, tr("Choose File"), dir);
-
-            if (!fileName.isEmpty())
-            {
-                auto cmd = gtApp->makeCommand(this, tr("File Input changed"));
-                Q_UNUSED(cmd);
-                m_fileChooser.setVal(fileName);
-            }
-        });
-
-        return b;
+    connect(&m_fileChooser, &GtAbstractProperty::changed, this, [this]() {
+        emit selectedFileChanged(selectedFile());
+        emit triggerNodeEvaluation();
     });
 
-    connect(&m_fileChooser, &GtAbstractProperty::changed,
-            this, &Node::triggerNodeEvaluation);
+    auto const updateFileNameConnection = [this](PortId portId, bool connected) {
+        if (portId != m_inName) return;
+        setNodeFlag(ResizableHOnly, !connected);
+        emit nodeChanged();
+        emit fileNameInputConnectionChanged(connected);
+    };
+
+    connect(this, &Node::portConnected, this, [updateFileNameConnection](PortId portId) {
+        updateFileNameConnection(portId, true);
+    });
+    connect(this, &Node::portDisconnected, this, [updateFileNameConnection](PortId portId) {
+        updateFileNameConnection(portId, false);
+    });
+}
+
+bool
+FileInputNode::isFileNameInputConnected() const
+{
+    auto const* p = port(m_inName);
+    return p && p->isConnected();
+}
+
+QString
+FileInputNode::selectedFile() const
+{
+    return m_fileChooser.get();
+}
+
+QString
+FileInputNode::dialogDirectory() const
+{
+    if (auto const& dirData = nodeData<StringData>(m_inDir))
+    {
+        return dirData->value();
+    }
+    return {};
+}
+
+void
+FileInputNode::setSelectedFile(QString const& filePath)
+{
+    if (filePath == selectedFile()) return;
+
+    auto cmd = gtApp->makeCommand(this, tr("File Input changed"));
+    Q_UNUSED(cmd);
+    m_fileChooser.setVal(filePath);
 }
 
 void
 FileInputNode::eval()
 {
-    QString const& filePath = m_fileChooser.get();
+    QString const& filePath = selectedFile();
 
     auto const& nameData = nodeData<StringData>(m_inName);
 

--- a/src/intelli/node/input/fileinput.h
+++ b/src/intelli/node/input/fileinput.h
@@ -25,6 +25,41 @@ public:
 
     Q_INVOKABLE FileInputNode();
 
+    /**
+     * @brief Returns whether the external file-name input port is connected.
+     * If connected, manual file picking UI should be hidden.
+     */
+    bool isFileNameInputConnected() const;
+
+    /**
+     * @brief Returns the currently selected file path stored in the node.
+     */
+    QString selectedFile() const;
+
+    /**
+     * @brief Returns the directory used as start location for file dialogs.
+     * This is derived from the optional directory input port data.
+     */
+    QString dialogDirectory() const;
+
+    /**
+     * @brief Sets the selected file path and records the change in undo/redo.
+     * @param filePath Absolute or relative path to the selected file.
+     */
+    void setSelectedFile(QString const& filePath);
+
+signals:
+
+    /**
+     * @brief Emitted whenever the stored selected file path changes.
+     */
+    void selectedFileChanged(QString const& filePath);
+
+    /**
+     * @brief Emitted when the file-name input port connection state changes.
+     */
+    void fileNameInputConnectionChanged(bool connected);
+
 protected:
 
     void eval() override;

--- a/src/intelli/node/input/intinput.cpp
+++ b/src/intelli/node/input/intinput.cpp
@@ -11,8 +11,7 @@
 #include <intelli/data/int.h>
 
 #include <intelli/gui/widgets/intinputwidget.h>
-
-#include <QString>
+#include <intelli/node/input/numberinputnode_utils.h>
 
 using namespace intelli;
 
@@ -39,46 +38,13 @@ IntInputNode::IntInputNode() :
     setNodeFlag(Resizable);
     setNodeEvalMode(NodeEvalMode::Blocking);
 
-    bool success = m_inputMode.registerEnum<IntInputWidget::InputMode>();
-    assert(success);
-
-    auto updateResizability = [this]() {
-        using InputMode = IntInputWidget::InputMode;
-        switch (static_cast<InputMode>(inputModeValue()))
-        {
-        case InputMode::SliderH:
-        case InputMode::LineEditBound:
-        case InputMode::LineEditUnbound:
-            setNodeFlag(ResizableHOnly, true);
-            break;
-        default:
-            setNodeFlag(ResizableHOnly, false);
-            break;
-        }
-    };
-
-    connect(&m_value, &GtIntProperty::changed,
-            this, [this]() { emit rangeChanged(); });
-    connect(&m_min, &GtIntProperty::changed,
-            this, [this]() {
-                emit rangeChanged();
-                emit nodeChanged();
-                emit triggerNodeEvaluation();
-            });
-    connect(&m_max, &GtIntProperty::changed,
-            this, [this]() {
-                emit rangeChanged();
-                emit nodeChanged();
-                emit triggerNodeEvaluation();
-            });
-    connect(&m_inputMode, &GtAbstractProperty::changed,
-            this, [this, updateResizability]() {
-                updateResizability();
-                emit inputModeChanged();
-                emit nodeChanged();
-            });
-
-    updateResizability();
+    detail::setupNumberInputNode<IntInputNode,
+                                 GtIntProperty,
+                                 GtIntProperty,
+                                 MetaEnumProperty,
+                                 IntInputWidget::InputMode>(
+        this, m_value, m_min, m_max, m_inputMode,
+        [this](bool enable) { setNodeFlag(ResizableHOnly, enable); });
 }
 
 int
@@ -137,19 +103,13 @@ IntInputNode::setUseBounds(bool value)
 int
 IntInputNode::inputModeValue() const
 {
-    if (!m_inputMode.isInitialized()) return 0;
-    return m_inputMode.getMetaEnum().keyToValue(m_inputMode.getVal().toUtf8());
+    return detail::inputModeValue(m_inputMode);
 }
 
 void
 IntInputNode::setInputModeValue(int value)
 {
-    if (!m_inputMode.isInitialized()) return;
-    const char* key = m_inputMode.getMetaEnum().valueToKey(value);
-    if (!key) return;
-    if (m_inputMode.getVal() == QLatin1String(key)) return;
-    bool success = true;
-    m_inputMode.setVal(key, &success);
+    detail::setInputModeValue(m_inputMode, value);
 }
 
 void

--- a/src/intelli/node/input/intinput.cpp
+++ b/src/intelli/node/input/intinput.cpp
@@ -12,6 +12,8 @@
 
 #include <intelli/gui/widgets/intinputwidget.h>
 
+#include <QString>
+
 using namespace intelli;
 
 IntInputNode::IntInputNode() :
@@ -37,80 +39,46 @@ IntInputNode::IntInputNode() :
     setNodeFlag(Resizable);
     setNodeEvalMode(NodeEvalMode::Blocking);
 
-    registerWidgetFactory([this]() {
+    bool success = m_inputMode.registerEnum<IntInputWidget::InputMode>();
+    assert(success);
+
+    auto updateResizability = [this]() {
         using InputMode = IntInputWidget::InputMode;
+        switch (static_cast<InputMode>(inputModeValue()))
+        {
+        case InputMode::SliderH:
+        case InputMode::LineEditBound:
+        case InputMode::LineEditUnbound:
+            setNodeFlag(ResizableHOnly, true);
+            break;
+        default:
+            setNodeFlag(ResizableHOnly, false);
+            break;
+        }
+    };
 
-        bool success = m_inputMode.registerEnum<InputMode>();
-        assert(success);
-
-        auto mode = m_inputMode.getEnum<InputMode>();
-        
-        auto* w = new IntInputWidget(mode);
-
-        auto onRangeChanged = [this, w](){
-            w->setRange(value(), lowerBound(), upperBound());
-            emit nodeChanged();
-            emit triggerNodeEvaluation();
-        };
-
-        auto onMinChanged = [=](){
-            int newVal = w->min();
-            if (lowerBound() != newVal) setLowerBound(newVal);
-        };
-
-        auto onMaxChanged = [=](){
-            int newVal = w->max();
-            if (upperBound() != newVal) setUpperBound(newVal);
-        };
-
-        auto onValueChanged = [=](){
-            int newVal = w->value();
-            if (value() != newVal)
-            {
-                setValue(newVal);
+    connect(&m_value, &GtIntProperty::changed,
+            this, [this]() { emit rangeChanged(); });
+    connect(&m_min, &GtIntProperty::changed,
+            this, [this]() {
+                emit rangeChanged();
+                emit nodeChanged();
                 emit triggerNodeEvaluation();
-            }
-        };
+            });
+    connect(&m_max, &GtIntProperty::changed,
+            this, [this]() {
+                emit rangeChanged();
+                emit nodeChanged();
+                emit triggerNodeEvaluation();
+            });
+    connect(&m_inputMode, &GtAbstractProperty::changed,
+            this, [this, updateResizability]() {
+                updateResizability();
+                emit inputModeChanged();
+                emit nodeChanged();
+            });
 
-        auto const updateMode= [this, w]() {
-            w->setInputMode(m_inputMode.getEnum<InputMode>());
-
-            setUseBounds(w->useBounds());
-
-            switch (w->inputMode())
-            {
-            case InputMode::SliderH:
-            case InputMode::LineEditBound:
-            case InputMode::LineEditUnbound:
-                setNodeFlag(ResizableHOnly, true);
-                break;
-            default:
-                setNodeFlag(ResizableHOnly, false);
-                break;
-            }
-
-            emit nodeChanged();
-        };
-        
-        connect(w, &IntInputWidget::valueComitted,
-                this, onValueChanged);
-        connect(w, &IntInputWidget::minChanged,
-                this, onMinChanged);
-        connect(w, &IntInputWidget::maxChanged,
-                this, onMaxChanged);
-
-        connect(&m_min, &GtIntProperty::changed,
-                w, onRangeChanged);
-        connect(&m_max, &GtIntProperty::changed,
-                w, onRangeChanged);
-        connect(&m_inputMode, &GtAbstractProperty::changed,
-                w, updateMode);
-
-        onRangeChanged();
-        updateMode();
-
-        return std::unique_ptr<QWidget>(w);
-    });
+    updateResizability();
 }
 
 int
@@ -164,6 +132,24 @@ IntInputNode::setUseBounds(bool value)
 {
     // cppcheck-suppress duplicateConditionalAssign
     if (m_useBounds != value) m_useBounds = value;
+}
+
+int
+IntInputNode::inputModeValue() const
+{
+    if (!m_inputMode.isInitialized()) return 0;
+    return m_inputMode.getMetaEnum().keyToValue(m_inputMode.getVal().toUtf8());
+}
+
+void
+IntInputNode::setInputModeValue(int value)
+{
+    if (!m_inputMode.isInitialized()) return;
+    const char* key = m_inputMode.getMetaEnum().valueToKey(value);
+    if (!key) return;
+    if (m_inputMode.getVal() == QLatin1String(key)) return;
+    bool success = true;
+    m_inputMode.setVal(key, &success);
 }
 
 void

--- a/src/intelli/node/input/intinput.h
+++ b/src/intelli/node/input/intinput.h
@@ -42,6 +42,14 @@ public:
     bool useBounds() const;
     void setUseBounds(bool value);
 
+    int inputModeValue() const;
+    void setInputModeValue(int value);
+
+signals:
+
+    void rangeChanged();
+    void inputModeChanged();
+
 protected:
 
     void eval() override;

--- a/src/intelli/node/input/numberinputnode_utils.h
+++ b/src/intelli/node/input/numberinputnode_utils.h
@@ -1,0 +1,96 @@
+/*
+ * GTlab IntelliGraph
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  SPDX-FileCopyrightText: 2026 German Aerospace Center
+ */
+
+#ifndef GT_INTELLI_NUMBERINPUTNODE_UTILS_H
+#define GT_INTELLI_NUMBERINPUTNODE_UTILS_H
+
+#include <QObject>
+#include <QString>
+
+#include <gt_abstractproperty.h>
+
+namespace intelli
+{
+namespace detail
+{
+
+template <typename ModePropT>
+inline int inputModeValue(ModePropT const& mode)
+{
+    if (!mode.isInitialized()) return 0;
+    return mode.getMetaEnum().keyToValue(mode.getVal().toUtf8());
+}
+
+template <typename ModePropT>
+inline void setInputModeValue(ModePropT& mode, int value)
+{
+    if (!mode.isInitialized()) return;
+    const char* key = mode.getMetaEnum().valueToKey(value);
+    if (!key) return;
+    if (mode.getVal() == QLatin1String(key)) return;
+    bool success = true;
+    mode.setVal(key, &success);
+}
+
+template <typename NodeT,
+          typename ValuePropT,
+          typename BoundPropT,
+          typename ModePropT,
+          typename InputModeEnum,
+          typename SetResizableFn>
+inline void setupNumberInputNode(NodeT* node,
+                                 ValuePropT& value,
+                                 BoundPropT& min,
+                                 BoundPropT& max,
+                                 ModePropT& mode,
+                                 SetResizableFn&& setResizableHOnly)
+{
+    bool success = mode.template registerEnum<InputModeEnum>();
+    assert(success);
+
+    auto updateResizability = [&mode, setResizableHOnly]() {
+        switch (static_cast<InputModeEnum>(inputModeValue(mode)))
+        {
+        case InputModeEnum::SliderH:
+        case InputModeEnum::LineEditBound:
+        case InputModeEnum::LineEditUnbound:
+            setResizableHOnly(true);
+            break;
+        default:
+            setResizableHOnly(false);
+            break;
+        }
+    };
+
+    QObject::connect(&value, &ValuePropT::changed,
+                     node, [node]() { emit node->rangeChanged(); });
+    QObject::connect(&min, &BoundPropT::changed,
+                     node, [node]() {
+                        emit node->rangeChanged();
+                        emit node->nodeChanged();
+                        emit node->triggerNodeEvaluation();
+                     });
+    QObject::connect(&max, &BoundPropT::changed,
+                     node, [node]() {
+                        emit node->rangeChanged();
+                        emit node->nodeChanged();
+                        emit node->triggerNodeEvaluation();
+                     });
+    QObject::connect(&mode, &GtAbstractProperty::changed,
+                     node, [node, updateResizability]() {
+                        updateResizability();
+                        emit node->inputModeChanged();
+                        emit node->nodeChanged();
+                     });
+
+    updateResizability();
+}
+
+} // namespace detail
+} // namespace intelli
+
+#endif // GT_INTELLI_NUMBERINPUTNODE_UTILS_H

--- a/src/intelli/node/input/objectinput.cpp
+++ b/src/intelli/node/input/objectinput.cpp
@@ -11,11 +11,6 @@
 #include <intelli/data/object.h>
 #include <intelli/nodedatainterface.h>
 
-#include <gt_application.h>
-#include <gt_project.h>
-
-#include <gt_propertyobjectlinkeditor.h>
-
 using namespace intelli;
 
 constexpr bool s_useSuperClass = true;
@@ -31,24 +26,6 @@ ObjectInputNode::ObjectInputNode() :
 
     m_out = addOutPort(makePort(typeId<ObjectData>())
                            .setCaptionVisible(false));
-
-    registerWidgetFactory([this]() {
-        auto* model = exec::nodeDataInterface(*this);
-
-        auto w = std::make_unique<GtPropertyObjectLinkEditor>();
-        w->setObjectLinkProperty(&m_object);
-        w->setScope(model ? model->scope() : m_object.object());
-
-        auto update = [w_ = w.get()](){
-            w_->updateText();
-        };
-
-        connect(this, &Node::evaluated, w.get(), update);
-
-        update();
-
-        return w;
-    });
 
     connect(&m_object, &GtAbstractProperty::changed,
             this, &ObjectInputNode::triggerNodeEvaluation);
@@ -73,6 +50,18 @@ ObjectInputNode::ObjectInputNode() :
     });
 }
 
+GtObjectLinkProperty&
+ObjectInputNode::objectProperty()
+{
+    return m_object;
+}
+
+GtObjectLinkProperty const&
+ObjectInputNode::objectProperty() const
+{
+    return m_object;
+}
+
 GtObject*
 ObjectInputNode::linkedObject(GtObject* root)
 {
@@ -94,6 +83,7 @@ ObjectInputNode::linkedObject(GtObject const* root) const
 void
 ObjectInputNode::setValue(QString const& uuid)
 {
+    if (m_object.getVal() == uuid) return;
     m_object.setVal(uuid);
 }
 

--- a/src/intelli/node/input/objectinput.h
+++ b/src/intelli/node/input/objectinput.h
@@ -25,6 +25,9 @@ public:
 
     Q_INVOKABLE ObjectInputNode();
 
+    GtObjectLinkProperty& objectProperty();
+    GtObjectLinkProperty const& objectProperty() const;
+
     /**
      * @brief linkedObject
      * @return

--- a/src/intelli/node/input/stringinput.cpp
+++ b/src/intelli/node/input/stringinput.cpp
@@ -10,8 +10,6 @@
 #include <intelli/node/input/stringinput.h>
 #include <intelli/data/string.h>
 
-#include <gt_lineedit.h>
-
 using namespace intelli;
 
 StringInputNode::StringInputNode() :
@@ -28,29 +26,9 @@ StringInputNode::StringInputNode() :
 
     connect(&m_value, &GtAbstractProperty::changed,
             this, &Node::triggerNodeEvaluation);
+    connect(&m_value, &GtAbstractProperty::changed,
+            this, [this]() { emit valueChanged(m_value.get()); });
 
-    registerWidgetFactory([this]() {
-        auto w = std::make_unique<GtLineEdit>();
-        w->setPlaceholderText(QStringLiteral("String"));
-        w->setMinimumWidth(50);
-
-        w->resize(100, w->sizeHint().height());
-
-        auto const updateProp = [this, w_ = w.get()](){
-            if(value() != w_->text()) setValue(w_->text());
-        };
-        auto const updateText = [this, w_ = w.get()](){
-            if (w_->text() != value()) w_->setText(value());
-        };
-
-        connect(w.get(), &GtLineEdit::focusOut, this, updateProp);
-        connect(w.get(), &GtLineEdit::clearFocusOut, this, updateProp);
-        connect(&m_value, &GtAbstractProperty::changed, w.get(), updateText);
-
-        updateText();
-
-        return w;
-    });
 }
 
 QString const&
@@ -62,6 +40,7 @@ StringInputNode::value() const
 void
 StringInputNode::setValue(QString value)
 {
+    if (m_value.get() == value) return;
     m_value = std::move(value);
 }
 

--- a/src/intelli/node/input/stringinput.h
+++ b/src/intelli/node/input/stringinput.h
@@ -29,6 +29,10 @@ public:
 
     void setValue(QString value);
 
+signals:
+
+    void valueChanged(QString const& value);
+
 protected:
 
     void eval() override;

--- a/src/intelli/node/numberdisplay.cpp
+++ b/src/intelli/node/numberdisplay.cpp
@@ -11,8 +11,6 @@
 
 #include "intelli/data/double.h"
 
-#include <gt_lineedit.h>
-
 using namespace intelli;
 
 
@@ -21,26 +19,17 @@ NumberDisplayNode::NumberDisplayNode() :
 {
     setNodeEvalMode(NodeEvalMode::Blocking);
 
-    PortId in = addInPort(makePort(typeId<DoubleData>()).setCaptionVisible(false));
+    addInPort(makePort(typeId<DoubleData>()).setCaptionVisible(false));
 
     setNodeFlag(ResizableHOnly);
-
-    registerWidgetFactory([=](){
-        auto w = std::make_unique<GtLineEdit>();
-
-        w->setReadOnly(true);
-        w->setMinimumWidth(75);
-        w->resize(w->minimumSizeHint());
-
-        auto const updateText = [this, in, w_ = w.get()](){
-            auto const& data = nodeData<DoubleData>(in);
-            w_->setText(QString::number(data ? data->value() : 0));
-        };
-        
-        connect(this, &Node::evaluated, w.get(), updateText);
-        updateText();
-
-        return w;
-    });
 }
 
+double
+NumberDisplayNode::displayValue() const
+{
+    auto const& inPorts = ports(PortType::In);
+    if (inPorts.empty()) return 0;
+
+    auto const& data = nodeData<DoubleData>(inPorts.front().id());
+    return data ? data->value() : 0;
+}

--- a/src/intelli/node/numberdisplay.h
+++ b/src/intelli/node/numberdisplay.h
@@ -22,6 +22,8 @@ class NumberDisplayNode : public Node
 public:
 
     Q_INVOKABLE NumberDisplayNode();
+
+    double displayValue() const;
 };
 
 } // namespace intelli

--- a/src/intelli/node/numbermath.cpp
+++ b/src/intelli/node/numbermath.cpp
@@ -11,8 +11,23 @@
 
 #include "intelli/data/double.h"
 
-#include <QComboBox>
-#include <QLayout>
+#include <QMetaType>
+
+namespace
+{
+static const int meta_math_operation = [](){
+    // DetachedExecutor connects signals by signature strings that can vary.
+    // Register common spellings to keep queued connections valid.
+    qRegisterMetaType<intelli::NumberMathNode::MathOperation>(
+        "MathOperation");
+    qRegisterMetaType<intelli::NumberMathNode::MathOperation>(
+        "NumberMathNode::MathOperation");
+    return qRegisterMetaType<intelli::NumberMathNode::MathOperation>(
+        "intelli::NumberMathNode::MathOperation");
+}();
+} // namespace
+
+
 
 using namespace intelli;
 
@@ -32,36 +47,27 @@ NumberMathNode::NumberMathNode() :
         QStringLiteral("result") // custom port caption
     });
 
-    registerWidgetFactory([=](){
-        auto base = makeBaseWidget();
-        auto w = new QComboBox();
-        base->layout()->addWidget(w);
-        w->addItems(QStringList{"+", "-", "*", "/", "pow"});
-
-        auto const update = [this, w](){
-            w->setCurrentText(toString(m_operation));
-        };
-
-        connect(&m_operation, &GtAbstractProperty::changed, w, update);
-
-        connect(w, &QComboBox::currentTextChanged,
-                this, [this, w](){
-            auto tmp = toMathOperation(w->currentText());
-            if (tmp == m_operation) return;
-
-            m_operation = tmp;
-            updatePortCaptions();
-        });
-
-        update();
-
-        return base;
-    });
-
     updatePortCaptions();
 
     connect(&m_operation, &GtAbstractProperty::changed,
             this, &Node::triggerNodeEvaluation);
+    connect(&m_operation, &GtAbstractProperty::changed,
+            this, [this]() { emit operationChanged(m_operation); });
+}
+
+NumberMathNode::MathOperation
+NumberMathNode::operation() const
+{
+    return m_operation;
+}
+
+void
+NumberMathNode::setOperation(MathOperation op)
+{
+    if (m_operation == op) return;
+
+    m_operation = op;
+    updatePortCaptions();
 }
 
 void

--- a/src/intelli/node/numbermath.h
+++ b/src/intelli/node/numbermath.h
@@ -14,6 +14,8 @@
 
 #include <gt_enumproperty.h>
 
+#include <QMetaType>
+
 namespace intelli
 {
 
@@ -35,6 +37,14 @@ public:
 
     Q_INVOKABLE NumberMathNode();
 
+    MathOperation operation() const;
+    void setOperation(MathOperation op);
+
+signals:
+
+    // Forwarded across threads (DetachedExecutor), so the enum must be a Qt metatype.
+    void operationChanged(MathOperation op);
+
 protected:
 
     void eval() override;
@@ -53,5 +63,8 @@ private:
 };
 
 } // namespace intelli
+
+// Required for queued connections of NumberMathNode::operationChanged.
+Q_DECLARE_METATYPE(intelli::NumberMathNode::MathOperation)
 
 #endif // GT_INTELLI_NUMBERMATHNODE_H

--- a/src/intelli/node/objectsink.cpp
+++ b/src/intelli/node/objectsink.cpp
@@ -11,8 +11,6 @@
 #include <intelli/data/object.h>
 #include <intelli/nodedatainterface.h>
 
-#include <QPushButton>
-
 #include "gt_application.h"
 #include "gt_datamodel.h"
 #include "gt_project.h"
@@ -29,23 +27,32 @@ ObjectSink::ObjectSink() :
 
     setNodeEvalMode(NodeEvalMode::Blocking);
 
-    // registering the widget factory
-    registerWidgetFactory([=](){
-        auto w = std::make_unique<QPushButton>("Export");
+    auto const updateExportEnabled = [this]() {
+        bool enabled = nodeData<ObjectData>(m_in) != nullptr;
+        if (m_canExport == enabled) return;
+        m_canExport = enabled;
+        emit exportEnabledChanged(enabled);
+    };
 
-        w->setEnabled(false);
-
-        connect(this, &Node::inputDataRecieved,
-                this, [this, w_ = w.get()](PortId portId){
-            auto data_tmp = nodeData<ObjectData>(portId);
-            w_->setEnabled(data_tmp != nullptr);
-        });
-
-        connect(w.get(), &QPushButton::clicked,
-                this, [this](){ doExport(); });
-
-        return w;
+    connect(this, &Node::inputDataRecieved,
+            this, [this, updateExportEnabled](PortId portId){
+        if (portId != m_in) return;
+        updateExportEnabled();
     });
+
+    updateExportEnabled();
+}
+
+bool
+ObjectSink::canExport() const
+{
+    return m_canExport;
+}
+
+void
+ObjectSink::exportObject()
+{
+    doExport();
 }
 
 void

--- a/src/intelli/node/objectsink.h
+++ b/src/intelli/node/objectsink.h
@@ -25,10 +25,19 @@ class ObjectSink : public Node
 public:
     Q_INVOKABLE ObjectSink();
 
+    bool canExport() const;
+
+public slots:
+    void exportObject();
+
+signals:
+    void exportEnabledChanged(bool enabled);
+
 private:
     PortId m_in;
 
     GtObjectLinkProperty m_target;
+    bool m_canExport{false};
 
 private slots:
     void doExport();

--- a/src/intelli/node/sleepy.cpp
+++ b/src/intelli/node/sleepy.cpp
@@ -30,7 +30,6 @@ SleepyNode::SleepyNode() :
     m_in  = addInPort(typeId<DoubleData>(), Required);
     m_out = addOutPort(typeId<DoubleData>());
 
-    // Widget creation moved to NodeUI.
 }
 
 bool

--- a/src/intelli/node/sleepy.cpp
+++ b/src/intelli/node/sleepy.cpp
@@ -30,28 +30,13 @@ SleepyNode::SleepyNode() :
     m_in  = addInPort(typeId<DoubleData>(), Required);
     m_out = addOutPort(typeId<DoubleData>());
 
-    registerWidgetFactory([this](){
-        auto w = std::make_unique<QLabel>();
+    // Widget creation moved to NodeUI.
+}
 
-        auto reset = [w_ = w.get(), this](){
-            if (nodeData<DoubleData>(m_in))
-                w_->setPixmap(gt::gui::icon::check().pixmap(20, 20));
-            else
-                w_->setPixmap(gt::gui::icon::cross().pixmap(20, 20));
-        };
-
-        auto update = [w_ = w.get()](int progress){
-            w_->setPixmap(progress != 100 ?
-                gt::gui::icon::processRunningIcon(progress).pixmap(20, 20) :
-                gt::gui::icon::check().pixmap(20, 20));
-        };
-        connect(this, &SleepyNode::timePassed, w.get(), update);
-        connect(this, &Node::inputDataRecieved, w.get(), reset);
-
-        reset();
-
-        return w;
-    });
+bool
+SleepyNode::hasInputData() const
+{
+    return nodeData<DoubleData>(m_in) != nullptr;
 }
 
 void

--- a/src/intelli/node/sleepy.h
+++ b/src/intelli/node/sleepy.h
@@ -24,6 +24,8 @@ public:
 
     Q_INVOKABLE SleepyNode();
 
+    bool hasInputData() const;
+
 signals:
 
     void timePassed(int progress);

--- a/src/intelli/node/stringbuilder.cpp
+++ b/src/intelli/node/stringbuilder.cpp
@@ -11,10 +11,6 @@
 
 #include <intelli/data/string.h>
 
-#include <gt_lineedit.h>
-
-#include <QLayout>
-
 using namespace intelli;
 
 StringBuilderNode::StringBuilderNode() :
@@ -31,35 +27,23 @@ StringBuilderNode::StringBuilderNode() :
     m_inB = addInPort({typeId<StringData>(), tr("%2")});
     m_out = addOutPort({typeId<StringData>(), tr("new_str")});
 
-    registerWidgetFactory([this]() {
-        auto b = makeBaseWidget();
-        auto w = new GtLineEdit();
-        w->setPlaceholderText(QStringLiteral("%1/%2"));
-        w->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-        w->setMinimumWidth(50);
-
-        b->layout()->addWidget(w);
-
-        auto const updateProp = [this, w](){
-            QString const& text = w->text();
-            if(m_pattern != text) m_pattern.setVal(text);
-        };
-        auto const updateText = [this, w = w](){
-            QString const& text = m_pattern.get();
-            if (w->text() != text) w->setText(text);
-        };
-
-        connect(w, &GtLineEdit::focusOut, this, updateProp);
-        connect(w, &GtLineEdit::clearFocusOut, this, updateProp);
-        connect(&m_pattern, &GtAbstractProperty::changed, w, updateText);
-
-        updateText();
-
-        return b;
-    });
-
     connect(&m_pattern, &GtAbstractProperty::changed,
             this, &Node::triggerNodeEvaluation);
+    connect(&m_pattern, &GtAbstractProperty::changed,
+            this, [this]() { emit patternChanged(m_pattern.get()); });
+}
+
+QString
+StringBuilderNode::pattern() const
+{
+    return m_pattern.get();
+}
+
+void
+StringBuilderNode::setPattern(QString const& pattern)
+{
+    if (m_pattern.get() == pattern) return;
+    m_pattern.setVal(pattern);
 }
 
 void

--- a/src/intelli/node/stringbuilder.h
+++ b/src/intelli/node/stringbuilder.h
@@ -25,6 +25,13 @@ public:
 
     Q_INVOKABLE StringBuilderNode();
 
+    QString pattern() const;
+    void setPattern(QString const& pattern);
+
+signals:
+
+    void patternChanged(QString const& pattern);
+
 protected:
 
     void eval() override;

--- a/src/intelli/node/stringselection.cpp
+++ b/src/intelli/node/stringselection.cpp
@@ -11,8 +11,6 @@
 #include "intelli/data/string.h"
 #include "intelli/data/stringlist.h"
 
-#include <QComboBox>
-
 using namespace intelli;
 
 StringSelectionNode::StringSelectionNode() :
@@ -27,42 +25,59 @@ StringSelectionNode::StringSelectionNode() :
 
     setNodeFlag(ResizableHOnly, true);
     
-    registerWidgetFactory([this]() {
-        auto w = std::make_unique<QComboBox>();
-
+    auto const updateOptions = [this]() {
         QStringList given;
-
         if (auto list = nodeData<StringListData>(m_in))
         {
             given = list->value();
         }
+        emit optionsChanged(given);
 
-        w->addItems(given);
+        if (given.isEmpty())
+        {
+            setSelection(QString{});
+            return;
+        }
 
-        m_selection = given.isEmpty() ? QString{} : given.first();
+        if (!given.contains(m_selection))
+        {
+            setSelection(given.first());
+        }
+    };
 
-        connect(w.get(), &QComboBox::currentTextChanged,
-                this, [this](QString const& newObjName) {
-                    this->m_selection = newObjName;
-                    emit triggerNodeEvaluation();
-                });
+    connect(this, &Node::inputDataRecieved,
+            this, [this, updateOptions](PortId portId)
+            {
+                if (portId != m_in) return;
+                updateOptions();
+            });
 
-        connect(this, &Node::inputDataRecieved,
-                w.get(), [this, wid = w.get()]()
-                {
-                    wid->clear();
-                    QStringList given;
-                    auto list = nodeData<StringListData>(m_in);
-                    if (list)
-                    {
-                        given = list->value();
-                    }
-                    wid->addItems(given);
-                    emit triggerNodeEvaluation();
-                });
+    updateOptions();
+}
 
-        return w;
-    });
+QString
+StringSelectionNode::selection() const
+{
+    return m_selection.get();
+}
+
+void
+StringSelectionNode::setSelection(QString const& selection)
+{
+    if (m_selection.get() == selection) return;
+    m_selection = selection;
+    emit selectionChanged(m_selection.get());
+    emit triggerNodeEvaluation();
+}
+
+QStringList
+StringSelectionNode::options() const
+{
+    if (auto list = nodeData<StringListData>(m_in))
+    {
+        return list->value();
+    }
+    return {};
 }
 
 void

--- a/src/intelli/node/stringselection.h
+++ b/src/intelli/node/stringselection.h
@@ -22,6 +22,15 @@ public:
 
     Q_INVOKABLE StringSelectionNode();
 
+    QString selection() const;
+    void setSelection(QString const& selection);
+    QStringList options() const;
+
+signals:
+
+    void selectionChanged(QString const& selection);
+    void optionsChanged(QStringList const& options);
+
 protected:
 
     void eval() override;

--- a/src/intelli/node/textdisplay.cpp
+++ b/src/intelli/node/textdisplay.cpp
@@ -12,17 +12,6 @@
 #include <intelli/data/string.h>
 #include <intelli/data/bytearray.h>
 
-#include <gt_application.h>
-#include <gt_xmlhighlighter.h>
-#include <gt_pyhighlighter.h>
-#include <gt_jshighlighter.h>
-#include <gt_xmlhighlighter.h>
-#include <gt_codeeditor.h>
-
-#include <QLayout>
-#include <QSyntaxHighlighter>
-#include <QTextDocument>
-
 using namespace intelli;
 
 TextDisplayNode::TextDisplayNode() :
@@ -34,62 +23,22 @@ TextDisplayNode::TextDisplayNode() :
     setNodeEvalMode(NodeEvalMode::Blocking);
     setNodeFlag(Resizable, true);
 
-    PortId in = addInPort(makePort(typeId<StringData>())
-                              .setCaptionVisible(false));
+    addInPort(makePort(typeId<StringData>())
+                  .setCaptionVisible(false));
+}
 
-    registerWidgetFactory([this, in](){
-        auto base = makeBaseWidget();
+QString
+TextDisplayNode::displayText() const
+{
+    auto const& inPorts = ports(PortType::In);
+    if (inPorts.empty()) return {};
 
-        auto* w = new GtCodeEditor();
-        base->layout()->addWidget(w);
+    auto const& data = nodeData<StringData>(inPorts.front().id());
+    return data ? data->value() : QString{};
+}
 
-        w->setMinimumSize(125, 25);
-        w->resize(400, 200);
-        w->setReadOnly(true);
-
-        // update sytnax highlighter
-        auto const updateHighlighter = [this, w](){
-            auto* document = w->document();
-            assert(document);
-
-            auto* highlighter = document->findChild<QSyntaxHighlighter*>();
-            if (highlighter) highlighter->deleteLater();
-
-            switch (m_textType.getVal())
-            {
-            case TextType::PlainText:
-                break;
-            case TextType::Xml:
-                new GtXmlHighlighter(document);
-                break;
-            case TextType::Python:
-                new GtPyHighlighter(document);
-                break;
-            case TextType::JavaScript:
-                new GtJsHighlighter(document);
-                break;
-            }
-        };
-
-        // update text
-        auto const updateText = [this, in, w](){
-            w->clear();
-            if (auto const& data = nodeData<StringData>(in))
-            {
-                w->setPlainText(data->value());
-            }
-        };
-
-        connect(this, &Node::inputDataRecieved,
-                w, updateText);
-        connect(this, qOverload<GtObject*, GtAbstractProperty*>(&Node::dataChanged),
-                w, updateHighlighter);
-        connect(gtApp, &GtApplication::themeChanged,
-                w, updateHighlighter);
-
-        updateText();
-        updateHighlighter();
-
-        return base;
-    });
+TextDisplayNode::TextType
+TextDisplayNode::textType() const
+{
+    return m_textType.getVal();
 }

--- a/src/intelli/node/textdisplay.h
+++ b/src/intelli/node/textdisplay.h
@@ -14,6 +14,8 @@
 
 #include <gt_enumproperty.h>
 
+class QString;
+
 namespace intelli
 {
 
@@ -34,6 +36,9 @@ public:
     Q_ENUM(TextType);
 
     Q_INVOKABLE TextDisplayNode();
+
+    QString displayText() const;
+    TextType textType() const;
 
 private:
 


### PR DESCRIPTION
## Summary

  This PR migrates IntelliGraph node widget customization away from the deprecated `Node::registerWidgetFactory(...)` API to the current `NodeUI`-based approach.

  The refactoring keeps runtime behavior equivalent while removing deprecated API usage node-by-node.

  ## What Changed

  ### Deprecated widget migration
  - Replaced legacy `registerWidgetFactory(...)` usage with dedicated `NodeUI` subclasses overriding `NodeUI::centralWidgetFactory(...)`.
  - Registered the new UI classes in `GtIntelliGraphModule::uiItems()`.

  ### Node/UI state synchronization improvements
  - Moved widget-specific logic into `NodeUI` classes.
  - Added explicit node state APIs + signals where needed (instead of sharing widget state implicitly).

  ### Code quality / maintenance
  - Reduced duplication between `IntInputNode` / `DoubleInputNode` and their UI classes via shared helpers.
  - Added comments/documentation in migrated UI code where behavior is non-obvious.

  ## Migrated Nodes

  Includes migration of the remaining deprecated widget-factory nodes, including input nodes and several exec/helper nodes e.g.
 - number math
 - directory source
 - object sink
 - string builder/selection
 - object/string/int/double input
 - sleepy
 - find direct child
 - generic calculator exec

  ## Verification

  - Manually validated migrated node UIs during migration
