### PR TITLE
Fix duplicate node creation from context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+ - Fixed duplicate node creation on linux system - #350
 
 ## [0.15.0] - 2025-10-27
 *This release is not ABI compatible with `0.14.0` and introduces small API changes*

--- a/src/intelli/gui/graphscene.cpp
+++ b/src/intelli/gui/graphscene.cpp
@@ -780,8 +780,11 @@ GraphScene::createSceneMenu(QPointF scenePos)
 
         menu->close();
     };
+
+    // `itemActivated` may also fire for a single click depending on the Qt
+    // platform style (notably on some Linux / remote desktop setups). Using
+    // `itemClicked` alone keeps node creation single-shot.
     connect(treeView, &QTreeWidget::itemClicked, menu, onClicked);
-    connect(treeView, &QTreeWidget::itemActivated, menu, onClicked);
 
     //Setup filtering
     connect(txtBox, &QLineEdit::textChanged, treeView, [treeView](QString const& text) {


### PR DESCRIPTION
On Linux setups with certain Qt platform styles, the node picker context menu could create two nodes from a single click. The menu connected both itemClicked and itemActivated to the same handler, so one selection could trigger node creation twice.

This change removes the redundant itemActivated connection and keeps node creation single-shot via itemClicked only.

Closes #350