### PR TITLE
Fix node data access initialization timing

### DIFF
--- a/src/intelli/gui/ui/node/stringselectionnodeui.cpp
+++ b/src/intelli/gui/ui/node/stringselectionnodeui.cpp
@@ -9,6 +9,7 @@
 
 #include <intelli/gui/graphics/nodeobject.h>
 #include <intelli/node/stringselection.h>
+#include <intelli/nodedatainterface.h>
 
 #include <QComboBox>
 #include <QGraphicsWidget>
@@ -50,7 +51,10 @@ StringSelectionNodeUI::centralWidgetFactory(Node const& n) const
             node->setSelection(text);
         });
 
-        updateOptions(node->options());
+        if (exec::nodeDataInterface(*node))
+        {
+            updateOptions(node->options());
+        }
         updateSelection(node->selection());
 
         return convertToGraphicsWidget(std::move(w), object);

--- a/src/intelli/node/input/graphuservariablesinput.cpp
+++ b/src/intelli/node/input/graphuservariablesinput.cpp
@@ -70,6 +70,8 @@ GraphUserVariablesInputNode::~GraphUserVariablesInputNode() = default;
 void
 GraphUserVariablesInputNode::nodeEvent(NodeEvent const* e)
 {
+    Node::nodeEvent(e);
+
     if (e->type() == NodeEventType::DataInterfaceAvailableEvent)
     {
         return updatePorts();

--- a/src/intelli/node/objectsink.cpp
+++ b/src/intelli/node/objectsink.cpp
@@ -37,6 +37,8 @@ ObjectSink::ObjectSink() :
 void
 ObjectSink::nodeEvent(NodeEvent const* e)
 {
+    Node::nodeEvent(e);
+
     if (e->type() == NodeEventType::DataInterfaceAvailableEvent)
     {
         updateExportEnabled();

--- a/src/intelli/node/objectsink.cpp
+++ b/src/intelli/node/objectsink.cpp
@@ -27,20 +27,29 @@ ObjectSink::ObjectSink() :
 
     setNodeEvalMode(NodeEvalMode::Blocking);
 
-    auto const updateExportEnabled = [this]() {
-        bool enabled = nodeData<ObjectData>(m_in) != nullptr;
-        if (m_canExport == enabled) return;
-        m_canExport = enabled;
-        emit exportEnabledChanged(enabled);
-    };
-
     connect(this, &Node::inputDataRecieved,
-            this, [this, updateExportEnabled](PortId portId){
+            this, [this](PortId portId){
         if (portId != m_in) return;
         updateExportEnabled();
     });
+}
 
-    updateExportEnabled();
+void
+ObjectSink::nodeEvent(NodeEvent const* e)
+{
+    if (e->type() == NodeEventType::DataInterfaceAvailableEvent)
+    {
+        updateExportEnabled();
+    }
+}
+
+void
+ObjectSink::updateExportEnabled()
+{
+    bool enabled = nodeData<ObjectData>(m_in) != nullptr;
+    if (m_canExport == enabled) return;
+    m_canExport = enabled;
+    emit exportEnabledChanged(enabled);
 }
 
 bool

--- a/src/intelli/node/objectsink.h
+++ b/src/intelli/node/objectsink.h
@@ -33,11 +33,16 @@ public slots:
 signals:
     void exportEnabledChanged(bool enabled);
 
+protected:
+    void nodeEvent(NodeEvent const* e) override;
+
 private:
     PortId m_in;
 
     GtObjectLinkProperty m_target;
     bool m_canExport{false};
+
+    void updateExportEnabled();
 
 private slots:
     void doExport();

--- a/src/intelli/node/stringselection.cpp
+++ b/src/intelli/node/stringselection.cpp
@@ -24,35 +24,13 @@ StringSelectionNode::StringSelectionNode() :
     m_selection.hide();
 
     setNodeFlag(ResizableHOnly, true);
-    
-    auto const updateOptions = [this]() {
-        QStringList given;
-        if (auto list = nodeData<StringListData>(m_in))
-        {
-            given = list->value();
-        }
-        emit optionsChanged(given);
-
-        if (given.isEmpty())
-        {
-            setSelection(QString{});
-            return;
-        }
-
-        if (!given.contains(m_selection))
-        {
-            setSelection(given.first());
-        }
-    };
 
     connect(this, &Node::inputDataRecieved,
-            this, [this, updateOptions](PortId portId)
+            this, [this](PortId portId)
             {
                 if (portId != m_in) return;
                 updateOptions();
             });
-
-    updateOptions();
 }
 
 QString
@@ -62,12 +40,15 @@ StringSelectionNode::selection() const
 }
 
 void
-StringSelectionNode::setSelection(QString const& selection)
+StringSelectionNode::setSelection(QString const& selection, bool triggerEvaluation)
 {
     if (m_selection.get() == selection) return;
     m_selection = selection;
     emit selectionChanged(m_selection.get());
-    emit triggerNodeEvaluation();
+    if (triggerEvaluation)
+    {
+        emit triggerNodeEvaluation();
+    }
 }
 
 QStringList
@@ -81,6 +62,28 @@ StringSelectionNode::options() const
 }
 
 void
+StringSelectionNode::updateOptions(bool triggerEvaluation)
+{
+    QStringList given;
+    if (auto list = nodeData<StringListData>(m_in))
+    {
+        given = list->value();
+    }
+    emit optionsChanged(given);
+
+    if (given.isEmpty())
+    {
+        setSelection(QString{}, triggerEvaluation);
+        return;
+    }
+
+    if (!given.contains(m_selection))
+    {
+        setSelection(given.first(), triggerEvaluation);
+    }
+}
+
+void
 StringSelectionNode::eval()
 {
     auto list = nodeData<StringListData>(m_in);
@@ -91,6 +94,11 @@ StringSelectionNode::eval()
     }
 
     QStringList listValues = list->value();
+    if (listValues.isEmpty())
+    {
+        setNodeData(m_out, nullptr);
+        return;
+    }
 
     if (listValues.contains(m_selection))
     {

--- a/src/intelli/node/stringselection.h
+++ b/src/intelli/node/stringselection.h
@@ -23,7 +23,7 @@ public:
     Q_INVOKABLE StringSelectionNode();
 
     QString selection() const;
-    void setSelection(QString const& selection);
+    void setSelection(QString const& selection, bool triggerEvaluation = true);
     QStringList options() const;
 
 signals:
@@ -36,6 +36,7 @@ protected:
     void eval() override;
 
 private:
+    void updateOptions(bool triggerEvaluation = true);
 
     /// ports for parent objet input and child object output
     PortId m_in, m_out;


### PR DESCRIPTION
This PR fixes initialization timing issues in IntelliGraph nodes after the NodeUI migration. This regression was introduced by the refactorings after 0.15 release.

  Changes:

  - Move StringSelectionNode UI startup logic out of eager data access during widget creation.
  - Avoid premature evaluation before the node has real input data.
  - Make empty StringListData a neutral state instead of a failure.
  - Keep ObjectSink and StringSelectionNode state updates tied to valid data availability.

  Result:

  - No more startup warnings from accessing node data too early.

## Summary by Sourcery

Fix initialization timing and data handling for IntelliGraph string selection and object sink nodes to avoid premature evaluation and empty-data failures.

Bug Fixes:
- Defer StringSelectionNode option updates until input data is available, preventing early data access and incorrect default selections.
- Treat empty StringListData as a neutral state in StringSelectionNode, avoiding crashes and failed evaluations when no options are provided.
- Ensure ObjectSink export enablement is updated only when the data interface is available, preventing premature state changes on startup.

Enhancements:
- Add explicit updateOptions and updateExportEnabled helpers to centralize node state updates and tie them to valid data availability.
- Gate initial StringSelectionNode UI option population on the presence of a node data interface to avoid spurious startup warnings.

## Summary by Sourcery

Fix initialization timing and data handling for IntelliGraph string selection and object sink nodes to avoid premature evaluation and empty-data failures.

Bug Fixes:
- Defer StringSelectionNode option updates and evaluation until input data is available, preventing early data access on construction.
- Treat empty StringListData as a neutral state in StringSelectionNode, emitting no output instead of forcing a selection or failing.
- Ensure ObjectSink export enablement is updated only once the node data interface is available, avoiding premature state changes on startup.

Enhancements:
- Introduce reusable updateOptions and updateExportEnabled helpers to centralize node state updates around valid data availability.
- Allow StringSelectionNode selection changes that do not affect the current value to skip triggering node evaluation.
- Gate initial StringSelectionNode UI option population on the presence of a node data interface to suppress spurious startup warnings.