### PR TITLE
Refactored node ui code into dedicated Widget classes

### DIFF
--- a/src/intelli/gui/ui/node/boolnodeui.cpp
+++ b/src/intelli/gui/ui/node/boolnodeui.cpp
@@ -9,90 +9,112 @@
 
 #include <intelli/gui/ui/node/boolnodeui.h>
 #include <intelli/data/bool.h>
-#include <intelli/node/booldisplay.h>
-#include <intelli/node/input/boolinput.h>
 
 #include <intelli/gui/graphics/nodeobject.h>
-#include <intelli/gui/widgets/booldisplaygraphicswidget.h>
 
 using namespace intelli;
+
+BoolDisplayNodeWidget::BoolDisplayNodeWidget(BoolDisplayNode& node) :
+    BoolDisplayGraphicsWidget(false)
+{
+    m_node = &node;
+
+    setReadOnly(true);
+
+    QObject::connect(m_node, &Node::inputDataRecieved,
+                     this, &BoolDisplayNodeWidget::updateValueFromNode);
+    QObject::connect(&m_node->m_displayMode, &GtAbstractProperty::changed,
+                     this, &BoolDisplayNodeWidget::updateDisplayModeFromNode);
+
+    updateValueFromNode();
+    updateDisplayModeFromNode();
+}
+
+NodeUI::QGraphicsWidgetPtr
+BoolDisplayNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    Q_UNUSED(object);
+
+    auto* node = qobject_cast<BoolDisplayNode*>(&source);
+    if (!node) return nullptr;
+
+    return std::make_unique<BoolDisplayNodeWidget>(*node);
+}
+
+void
+BoolDisplayNodeWidget::updateValueFromNode()
+{
+    auto const& data = m_node->nodeData<BoolData>(m_node->m_in);
+    setValue(data ? data->value() : false);
+}
+
+void
+BoolDisplayNodeWidget::updateDisplayModeFromNode()
+{
+    using DisplayMode = BoolDisplayGraphicsWidget::DisplayMode;
+
+    setDisplayMode(m_node->m_displayMode.getEnum<DisplayMode>());
+    emit m_node->nodeChanged();
+}
+
+BoolInputNodeWidget::BoolInputNodeWidget(BoolInputNode& node) :
+    BoolDisplayGraphicsWidget(false)
+{
+    m_node = &node;
+
+    QObject::connect(this, &BoolDisplayGraphicsWidget::valueChanged,
+                     this, &BoolInputNodeWidget::updateNodeValueFromWidget);
+    QObject::connect(&m_node->m_value, &GtAbstractProperty::changed,
+                     this, &BoolInputNodeWidget::updateWidgetValueFromNode);
+    QObject::connect(&m_node->m_displayMode, &GtAbstractProperty::changed,
+                     this, &BoolInputNodeWidget::updateDisplayModeFromNode);
+
+    updateWidgetValueFromNode();
+    updateDisplayModeFromNode();
+}
+
+NodeUI::QGraphicsWidgetPtr
+BoolInputNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    Q_UNUSED(object);
+
+    auto* node = qobject_cast<BoolInputNode*>(&source);
+    if (!node) return nullptr;
+
+    return std::make_unique<BoolInputNodeWidget>(*node);
+}
+
+void
+BoolInputNodeWidget::updateNodeValueFromWidget(bool value)
+{
+    if (value != m_node->value())
+    {
+        m_node->setValue(value);
+    }
+}
+
+void
+BoolInputNodeWidget::updateWidgetValueFromNode()
+{
+    setValue(m_node->value());
+}
+
+void
+BoolInputNodeWidget::updateDisplayModeFromNode()
+{
+    using DisplayMode = BoolDisplayGraphicsWidget::DisplayMode;
+
+    setDisplayMode(m_node->m_displayMode.getEnum<DisplayMode>());
+    emit m_node->nodeChanged();
+}
 
 BoolNodeUI::BoolNodeUI() = default;
 
 NodeUI::WidgetFactoryFunction
 BoolNodeUI::centralWidgetFactory(Node const& n) const
 {
-    if (qobject_cast<BoolDisplayNode const*>(&n))
-    {
-        return [this](Node& source, NodeGraphicsObject& /*object*/) -> QGraphicsWidgetPtr {
-            auto* node = qobject_cast<BoolDisplayNode*>(&source);
-            if (!node) return nullptr;
-
-            using DisplayMode = BoolDisplayGraphicsWidget::DisplayMode;
-
-            bool success = node->m_displayMode.registerEnum<DisplayMode>();
-            assert(success);
-
-            auto mode = node->m_displayMode.getEnum<DisplayMode>();
-
-            auto wPtr = std::make_unique<BoolDisplayGraphicsWidget>(false, mode);
-            auto* w = wPtr.get();
-            w->setReadOnly(true);
-
-            auto updateWidget = [node, w](){
-                auto const& data = node->nodeData<BoolData>(node->m_in);
-                w->setValue(data ? data->value() : false);
-            };
-            auto const updateMode= [node, w]() {
-                w->setDisplayMode(node->m_displayMode.getEnum<DisplayMode>());
-                emit node->nodeChanged();
-            };
-
-            QObject::connect(node, &Node::inputDataRecieved, w, updateWidget);
-            QObject::connect(&node->m_displayMode, &GtAbstractProperty::changed, w, updateMode);
-
-            updateWidget();
-            updateMode();
-
-            return wPtr;
-        };
-    }
-    if (qobject_cast<BoolInputNode const*>(&n))
-    {
-        return [this](Node& source, NodeGraphicsObject& /*object*/) -> QGraphicsWidgetPtr {
-            auto* node = qobject_cast<BoolInputNode*>(&source);
-            if (!node) return nullptr;
-
-            using DisplayMode = BoolDisplayGraphicsWidget::DisplayMode;
-
-            bool success = node->m_displayMode.registerEnum<DisplayMode>();
-            assert(success);
-
-            auto mode = node->m_displayMode.getEnum<DisplayMode>();
-
-            auto wPtr = std::make_unique<BoolDisplayGraphicsWidget>(false, mode);
-            auto* w = wPtr.get();
-
-            auto const updateProp = [node, w]() {
-                if (w->value() != node->value()) node->setValue(w->value());
-            };
-            auto const updateWidget = [node, w]() {
-                w->setValue(node->value());
-            };
-            auto const updateMode= [node, w]() {
-                w->setDisplayMode(node->m_displayMode.getEnum<DisplayMode>());
-                emit node->nodeChanged();
-            };
-
-            QObject::connect(w, &BoolDisplayGraphicsWidget::valueChanged, node, updateProp);
-            QObject::connect(&node->m_value, &GtAbstractProperty::changed, w, updateWidget);
-            QObject::connect(&node->m_displayMode, &GtAbstractProperty::changed, w, updateMode);
-
-            updateWidget();
-
-            return wPtr;
-        };
-    }
+    if (qobject_cast<BoolDisplayNode const*>(&n)) return &BoolDisplayNodeWidget::create;
+    if (qobject_cast<BoolInputNode const*>(&n)) return &BoolInputNodeWidget::create;
 
     return {};
 }

--- a/src/intelli/gui/ui/node/boolnodeui.h
+++ b/src/intelli/gui/ui/node/boolnodeui.h
@@ -57,7 +57,7 @@ private slots:
 
 private:
 
-    BoolInputNode* m_node = nullptr;
+    BoolInputNode* m_node{nullptr};
 };
 
 class BoolNodeUI : public NodeUI

--- a/src/intelli/gui/ui/node/boolnodeui.h
+++ b/src/intelli/gui/ui/node/boolnodeui.h
@@ -11,9 +11,54 @@
 #define GT_INTELLI_BOOLNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <intelli/gui/widgets/booldisplaygraphicswidget.h>
+
+#include <intelli/node/booldisplay.h>
+#include <intelli/node/input/boolinput.h>
 
 namespace intelli
 {
+
+class NodeGraphicsObject;
+
+class BoolDisplayNodeWidget : public BoolDisplayGraphicsWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit BoolDisplayNodeWidget(BoolDisplayNode& node);
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateValueFromNode();
+    void updateDisplayModeFromNode();
+
+private:
+
+    BoolDisplayNode* m_node = nullptr;
+};
+
+class BoolInputNodeWidget : public BoolDisplayGraphicsWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit BoolInputNodeWidget(BoolInputNode& node);
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateNodeValueFromWidget(bool value);
+    void updateWidgetValueFromNode();
+    void updateDisplayModeFromNode();
+
+private:
+
+    BoolInputNode* m_node = nullptr;
+};
 
 class BoolNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
+++ b/src/intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
@@ -13,13 +13,89 @@
 #include <gt_abstractproperty.h>
 #include <gt_existingdirectoryproperty.h>
 #include <gt_filedialog.h>
-#include <gt_propertyfilechoosereditor.h>
 
 #include <QApplication>
 #include <QGraphicsWidget>
 #include <QPushButton>
 
 using namespace intelli;
+
+ExistingDirectorySourceNodeWidget::ExistingDirectorySourceNodeWidget(ExistingDirectorySourceNode& node) :
+    GtPropertyFileChooserEditor()
+{
+    m_node = &node;
+
+    setMinimumWidth(120);
+
+    // Keep a dedicated UI property so the editor can own lifetime/updates.
+    m_property = new GtExistingDirectoryProperty("ui_directory",
+                                                  QObject::tr("Directory"),
+                                                  QObject::tr("Directory"));
+    m_property->setParent(this);
+    m_property->setVal(m_node->directory());
+    setFileChooserProperty(m_property);
+
+    QObject::connect(m_node, &ExistingDirectorySourceNode::directoryChanged,
+                     this, &ExistingDirectorySourceNodeWidget::syncPropertyFromNode);
+    QObject::connect(m_property, &GtAbstractProperty::changed,
+                     this, &ExistingDirectorySourceNodeWidget::syncNodeFromProperty);
+
+    updateSelectButton();
+}
+
+NodeUI::QGraphicsWidgetPtr
+ExistingDirectorySourceNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<ExistingDirectorySourceNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<ExistingDirectorySourceNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+ExistingDirectorySourceNodeWidget::syncPropertyFromNode(QString const& path)
+{
+    if (m_property->get() == path) return;
+    m_property->setVal(path);
+}
+
+void
+ExistingDirectorySourceNodeWidget::syncNodeFromProperty()
+{
+    m_node->setDirectory(m_property->get());
+}
+
+void
+ExistingDirectorySourceNodeWidget::chooseDirectory()
+{
+    QWidget* dialogParent = QApplication::activeWindow();
+    if (!dialogParent) dialogParent = this;
+
+    auto const directory = GtFileDialog::getExistingDirectory(
+        dialogParent,
+        QObject::tr("Choose Directory"),
+        m_node->directory());
+    if (directory.isEmpty()) return;
+
+    m_property->setVal(directory);
+}
+
+void
+ExistingDirectorySourceNodeWidget::updateSelectButton()
+{
+    auto const& buttons = findChildren<QPushButton*>();
+    if (buttons.empty()) return;
+
+    // Override the editor's select-button handler so we can choose
+    // a stable top-level parent for the dialog in the graphics scene.
+    QPushButton* btn = buttons.last();
+    if (!btn) return;
+
+    btn->disconnect();
+    QObject::connect(btn, &QPushButton::clicked,
+                     this, &ExistingDirectorySourceNodeWidget::chooseDirectory);
+}
 
 ExistingDirectorySourceNodeUI::ExistingDirectorySourceNodeUI() = default;
 
@@ -28,60 +104,5 @@ ExistingDirectorySourceNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<ExistingDirectorySourceNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<ExistingDirectorySourceNode*>(&source);
-        if (!node) return nullptr;
-
-        // Editor widget is embedded via QGraphicsProxyWidget.
-        auto w = std::make_unique<GtPropertyFileChooserEditor>();
-        w->setMinimumWidth(120);
-
-        // Keep a dedicated UI property so the editor can own lifetime/updates.
-        auto* prop = new GtExistingDirectoryProperty("ui_directory",
-                                                     QObject::tr("Directory"),
-                                                     QObject::tr("Directory"));
-        prop->setParent(w.get());
-        prop->setVal(node->directory());
-        w->setFileChooserProperty(prop);
-
-        // Sync node -> UI.
-        QObject::connect(node, &ExistingDirectorySourceNode::directoryChanged,
-                         w.get(), [prop](QString const& path) {
-            if (prop->get() == path) return;
-            prop->setVal(path);
-        });
-
-        // Sync UI -> node.
-        QObject::connect(prop, &GtAbstractProperty::changed,
-                         w.get(), [node, prop]() {
-            node->setDirectory(prop->get());
-        });
-
-        auto const& buttons = w->findChildren<QPushButton*>();
-        if (!buttons.empty())
-        {
-            // Override the editor's select-button handler so we can choose
-            // a stable top-level parent for the dialog in the graphics scene.
-            QPushButton* btn = buttons.last();
-
-            if (btn)
-            {
-                btn->disconnect();
-                QObject::connect(btn, &QPushButton::clicked, w.get(), [node, w_ = w.get(), prop]() {
-                    QWidget* dialogParent = QApplication::activeWindow();
-                    if (!dialogParent) dialogParent = w_;
-
-                    auto const directory = GtFileDialog::getExistingDirectory(
-                        dialogParent,
-                        QObject::tr("Choose Directory"),
-                        node->directory());
-                    if (directory.isEmpty()) return;
-
-                    prop->setVal(directory);
-                });
-            }
-        }
-
-        return convertToGraphicsWidget(std::move(w), object);
-    };
+    return &ExistingDirectorySourceNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
+++ b/src/intelli/gui/ui/node/existingdirectorysourcenodeui.cpp
@@ -28,7 +28,7 @@ ExistingDirectorySourceNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<ExistingDirectorySourceNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<ExistingDirectorySourceNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/existingdirectorysourcenodeui.h
+++ b/src/intelli/gui/ui/node/existingdirectorysourcenodeui.h
@@ -9,9 +9,39 @@
 #define GT_INTELLI_EXISTINGDIRECTORYSOURCENODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <gt_propertyfilechoosereditor.h>
+
+class GtExistingDirectoryProperty;
 
 namespace intelli
 {
+
+class ExistingDirectorySourceNode;
+class NodeGraphicsObject;
+
+class ExistingDirectorySourceNodeWidget : public GtPropertyFileChooserEditor
+{
+    Q_OBJECT
+
+public:
+
+    explicit ExistingDirectorySourceNodeWidget(ExistingDirectorySourceNode& node);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void syncPropertyFromNode(QString const& path);
+    void syncNodeFromProperty();
+    void chooseDirectory();
+
+private:
+
+    void updateSelectButton();
+
+    ExistingDirectorySourceNode* m_node{};
+    GtExistingDirectoryProperty* m_property{};
+};
 
 class ExistingDirectorySourceNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/fileinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/fileinputnodeui.cpp
@@ -30,7 +30,7 @@ FileInputNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<FileInputNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<FileInputNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/fileinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/fileinputnodeui.cpp
@@ -23,6 +23,100 @@
 
 using namespace intelli;
 
+FileInputNodeWidget::FileInputNodeWidget(FileInputNode& node, QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+    lay->setSpacing(0);
+
+    m_editor = new GtPropertyFileChooserEditor(this);
+    lay->addWidget(m_editor);
+
+    m_editor->setMinimumWidth(150);
+
+    m_fileProp = new GtOpenFileNameProperty("ui_file",
+                                            QObject::tr("File"),
+                                            QObject::tr("File Path"),
+                                            QStringList{});
+    m_fileProp->setParent(m_editor);
+    m_fileProp->setVal(m_node->selectedFile());
+    m_editor->setFileChooserProperty(m_fileProp);
+
+    QObject::connect(m_node, &FileInputNode::fileNameInputConnectionChanged,
+                     this, &FileInputNodeWidget::updateWidgetVisibility);
+    QObject::connect(m_node, &FileInputNode::selectedFileChanged,
+                     this, &FileInputNodeWidget::syncPropertyFromNode);
+    QObject::connect(m_fileProp, &GtAbstractProperty::changed,
+                     this, &FileInputNodeWidget::syncNodeFromProperty);
+
+    updateWidgetVisibility(m_node->isFileNameInputConnected());
+    updateSelectButton();
+}
+
+NodeUI::QGraphicsWidgetPtr
+FileInputNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<FileInputNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<FileInputNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+FileInputNodeWidget::updateWidgetVisibility(bool connected)
+{
+    m_editor->setVisible(!connected);
+    setMinimumWidth(connected ? 10 : m_editor->minimumWidth());
+    adjustSize();
+}
+
+void
+FileInputNodeWidget::syncPropertyFromNode(QString const& path)
+{
+    if (m_fileProp->get() == path) return;
+    m_fileProp->setVal(path);
+}
+
+void
+FileInputNodeWidget::syncNodeFromProperty()
+{
+    m_node->setSelectedFile(m_fileProp->get());
+}
+
+void
+FileInputNodeWidget::chooseFile()
+{
+    QWidget* dialogParent = QApplication::activeWindow();
+    if (!dialogParent) dialogParent = this;
+
+    auto const fileName = GtFileDialog::getOpenFileName(
+        dialogParent,
+        QObject::tr("Choose File"),
+        m_node->dialogDirectory());
+    if (fileName.isEmpty()) return;
+
+    m_fileProp->setVal(fileName);
+}
+
+void
+FileInputNodeWidget::updateSelectButton()
+{
+    auto const& btns = m_editor->findChildren<QPushButton*>();
+    if (btns.empty()) return;
+
+    // In GtPropertyFileChooserEditor, the select button is added last.
+    QPushButton* btn = btns.last();
+    if (!btn) return;
+
+    btn->disconnect();
+    QObject::connect(btn, &QPushButton::clicked,
+                     this, &FileInputNodeWidget::chooseFile);
+}
+
 FileInputNodeUI::FileInputNodeUI() = default;
 
 NodeUI::WidgetFactoryFunction
@@ -30,67 +124,5 @@ FileInputNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<FileInputNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<FileInputNode*>(&source);
-        if (!node) return nullptr;
-
-        auto b = utils::makeWidgetWithLayout();
-        auto* lay = b->layout();
-
-        auto* w = new GtPropertyFileChooserEditor();
-        lay->addWidget(w);
-
-        w->setMinimumWidth(150);
-
-        auto* fileProp = new GtOpenFileNameProperty("ui_file",
-                                                    QObject::tr("File"),
-                                                    QObject::tr("File Path"),
-                                                    QStringList{});
-        fileProp->setParent(w);
-        fileProp->setVal(node->selectedFile());
-        w->setFileChooserProperty(fileProp);
-
-        auto const updateWidget = [w, b_ = b.get()](bool connected) {
-            w->setVisible(!connected);
-            b_->setMinimumWidth(connected ? 10 : w->minimumWidth());
-            b_->resize(b_->minimumSize());
-        };
-
-        QObject::connect(node, &FileInputNode::fileNameInputConnectionChanged, w, updateWidget);
-        QObject::connect(node, &FileInputNode::selectedFileChanged, w, [fileProp](QString const& path) {
-            if (fileProp->get() == path) return;
-            fileProp->setVal(path);
-        });
-        QObject::connect(fileProp, &GtAbstractProperty::changed, w, [node, fileProp]() {
-            node->setSelectedFile(fileProp->get());
-        });
-        updateWidget(node->isFileNameInputConnected());
-
-        auto const& btns = w->findChildren<QPushButton*>();
-        if (!btns.empty())
-        {
-            // Override the editor's select-button handler so we can choose
-            // a stable top-level parent for the dialog in the graphics scene.
-            // In GtPropertyFileChooserEditor, the select button is added last.
-            QPushButton* btn = btns.last();
-
-            if (btn)
-            {
-                btn->disconnect();
-                QObject::connect(btn, &QPushButton::clicked, w, [node, w, fileProp]() {
-                    QWidget* dialogParent = QApplication::activeWindow();
-                    if (!dialogParent) dialogParent = w;
-
-                    auto const fileName = GtFileDialog::getOpenFileName(dialogParent,
-                                                                        QObject::tr("Choose File"),
-                                                                        node->dialogDirectory());
-                    if (fileName.isEmpty()) return;
-
-                    fileProp->setVal(fileName);
-                });
-            }
-        }
-
-        return convertToGraphicsWidget(std::move(b), object);
-    };
+    return &FileInputNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/fileinputnodeui.h
+++ b/src/intelli/gui/ui/node/fileinputnodeui.h
@@ -9,9 +9,42 @@
 #define GT_INTELLI_FILEINPUTNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <QWidget>
+
+class GtOpenFileNameProperty;
+class GtPropertyFileChooserEditor;
 
 namespace intelli
 {
+
+class FileInputNode;
+class NodeGraphicsObject;
+
+class FileInputNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit FileInputNodeWidget(FileInputNode& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateWidgetVisibility(bool connected);
+    void syncPropertyFromNode(QString const& path);
+    void syncNodeFromProperty();
+    void chooseFile();
+
+private:
+
+    void updateSelectButton();
+
+    FileInputNode* m_node{};
+    GtPropertyFileChooserEditor* m_editor{};
+    GtOpenFileNameProperty* m_fileProp{};
+};
 
 class FileInputNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/finddirectchildnodeui.cpp
+++ b/src/intelli/gui/ui/node/finddirectchildnodeui.cpp
@@ -15,6 +15,46 @@
 
 using namespace intelli;
 
+FindDirectChildNodeWidget::FindDirectChildNodeWidget(FindDirectChildNode& node) :
+    FindDirectChildWidget()
+{
+    m_node = &node;
+
+    QObject::connect(this, &FindDirectChildWidget::updateClass,
+                     m_node, &FindDirectChildNode::setTargetClassName);
+    QObject::connect(this, &FindDirectChildWidget::updateObjectName,
+                     m_node, &FindDirectChildNode::setTargetObjectName);
+
+    QObject::connect(m_node, &FindDirectChildNode::targetClassNameChanged,
+                     this, &FindDirectChildWidget::setClassNameWidget);
+    QObject::connect(m_node, &FindDirectChildNode::targetObjectNameChanged,
+                     this, &FindDirectChildWidget::setObjectNameWidget);
+    QObject::connect(m_node, &Node::inputDataRecieved,
+                     this, &FindDirectChildNodeWidget::updateNameCompleterFromNode);
+
+    setClassNameWidget(m_node->targetClassName());
+    setObjectNameWidget(m_node->targetObjectName());
+    updateNameCompleterFromNode();
+}
+
+NodeUI::QGraphicsWidgetPtr
+FindDirectChildNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<FindDirectChildNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<FindDirectChildNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+FindDirectChildNodeWidget::updateNameCompleterFromNode()
+{
+    if (!m_node) return;
+
+    updateNameCompleter(m_node->inputObject());
+}
+
 FindDirectChildNodeUI::FindDirectChildNodeUI() = default;
 
 NodeUI::WidgetFactoryFunction
@@ -22,40 +62,5 @@ FindDirectChildNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<FindDirectChildNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<FindDirectChildNode*>(&source);
-        if (!node) return nullptr;
-
-        auto w = std::make_unique<FindDirectChildWidget>();
-
-        w->updateNameCompleter(node->inputObject());
-
-        QObject::connect(w.get(), &FindDirectChildWidget::updateClass,
-                         w.get(), [node](QString const& newClass) {
-            node->setTargetClassName(newClass);
-        });
-        QObject::connect(node, &FindDirectChildNode::targetClassNameChanged,
-                         w.get(), [w_ = w.get()](QString const&) {
-            w_->updateClassText();
-        });
-
-        QObject::connect(w.get(), &FindDirectChildWidget::updateObjectName,
-                         w.get(), [node](QString const& newObjName) {
-            node->setTargetObjectName(newObjName);
-        });
-        QObject::connect(node, &FindDirectChildNode::targetObjectNameChanged,
-                         w.get(), [w_ = w.get()](QString const&) {
-            w_->updateNameText();
-        });
-
-        QObject::connect(node, &Node::inputDataRecieved,
-                         w.get(), [node, w_ = w.get()](PortId) {
-            w_->updateNameCompleter(node->inputObject());
-        });
-
-        w->setClassNameWidget(node->targetClassName());
-        w->setObjectNameWidget(node->targetObjectName());
-
-        return convertToGraphicsWidget(std::move(w), object);
-    };
+    return &FindDirectChildNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/finddirectchildnodeui.cpp
+++ b/src/intelli/gui/ui/node/finddirectchildnodeui.cpp
@@ -22,7 +22,7 @@ FindDirectChildNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<FindDirectChildNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<FindDirectChildNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/finddirectchildnodeui.h
+++ b/src/intelli/gui/ui/node/finddirectchildnodeui.h
@@ -9,9 +9,32 @@
 #define GT_INTELLI_FINDDIRECTCHILDNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <intelli/gui/widgets/finddirectchildwidget.h>
 
 namespace intelli
 {
+
+class FindDirectChildNode;
+class NodeGraphicsObject;
+
+class FindDirectChildNodeWidget : public FindDirectChildWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit FindDirectChildNodeWidget(FindDirectChildNode& node);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateNameCompleterFromNode();
+
+private:
+
+    FindDirectChildNode* m_node{};
+};
 
 class FindDirectChildNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/genericcalculatorexecnodeui.cpp
+++ b/src/intelli/gui/ui/node/genericcalculatorexecnodeui.cpp
@@ -29,7 +29,7 @@ GenericCalculatorExecNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<GenericCalculatorExecNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<GenericCalculatorExecNode*>(&source);
         if (!node) return nullptr;
 
@@ -51,7 +51,7 @@ GenericCalculatorExecNodeUI::centralWidgetFactory(Node const& n) const
         view->setAnimated(false);
         lay->addWidget(view);
 
-        auto updateView = [view, node](){
+        auto updateView = [this, view, node](){
             view->setObject(nullptr);
 
             auto obj = node->currentObject();

--- a/src/intelli/gui/ui/node/genericcalculatorexecnodeui.cpp
+++ b/src/intelli/gui/ui/node/genericcalculatorexecnodeui.cpp
@@ -20,7 +20,84 @@
 #include <QGraphicsWidget>
 #include <QVBoxLayout>
 
+#include <cassert>
+
 using namespace intelli;
+
+GenericCalculatorExecNodeWidget::GenericCalculatorExecNodeWidget(GenericCalculatorExecNode& node,
+                                                                 QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+
+    m_classEdit = new QComboBox(this);
+    m_classEdit->addItems(GenericCalculatorExecNode::classIdents());
+    m_classEdit->setStyleSheet(gt::gui::stylesheet::comboBox());
+    lay->addWidget(m_classEdit);
+
+    auto* model = exec::nodeDataInterface(*m_node);
+    GtObject* scope = model ? model->scope() : static_cast<GtObject*>(gtApp->currentProject());
+    assert(scope);
+
+    m_view = new GtPropertyTreeView(scope, this);
+    m_view->setAnimated(false);
+    lay->addWidget(m_view);
+
+    QObject::connect(m_classEdit, &QComboBox::currentTextChanged,
+                     this, &GenericCalculatorExecNodeWidget::updateClassFromEditor);
+    QObject::connect(m_node, &GenericCalculatorExecNode::classNameChanged,
+                     this, &GenericCalculatorExecNodeWidget::updateClassEditorFromNode);
+    QObject::connect(m_node, &GenericCalculatorExecNode::currentObjectChanged,
+                     this, &GenericCalculatorExecNodeWidget::updateCurrentObjectView);
+
+    m_node->syncConnectedPorts();
+
+    m_node->className().isEmpty() ? updateClassFromEditor(m_classEdit->currentText())
+                                  : updateClassEditorFromNode(m_node->className());
+    updateCurrentObjectView();
+}
+
+NodeUI::QGraphicsWidgetPtr
+GenericCalculatorExecNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<GenericCalculatorExecNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<GenericCalculatorExecNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+GenericCalculatorExecNodeWidget::updateCurrentObjectView()
+{
+    m_view->setObject(nullptr);
+
+    auto obj = m_node->currentObject();
+    if (!obj) return;
+
+    m_view->setObject(obj);
+    // collapse first category
+    m_view->collapse(m_view->model()->index(0, 0, m_view->rootIndex()));
+
+    QObject::connect(obj, qOverload<GtObject*, GtAbstractProperty*>(&GtObject::dataChanged),
+                     m_node, &GenericCalculatorExecNode::onCurrentObjectDataChanged,
+                     Qt::UniqueConnection);
+}
+
+void
+GenericCalculatorExecNodeWidget::updateClassFromEditor(QString const& classText)
+{
+    m_node->setClassName(GenericCalculatorExecNode::classNameFromIdent(classText));
+}
+
+void
+GenericCalculatorExecNodeWidget::updateClassEditorFromNode(QString const& className)
+{
+    m_classEdit->setCurrentText(GenericCalculatorExecNode::identFromClassName(className));
+}
 
 GenericCalculatorExecNodeUI::GenericCalculatorExecNodeUI() = default;
 
@@ -29,63 +106,5 @@ GenericCalculatorExecNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<GenericCalculatorExecNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<GenericCalculatorExecNode*>(&source);
-        if (!node) return nullptr;
-
-        auto w = std::make_unique<QWidget>();
-        auto* lay = new QVBoxLayout;
-        w->setLayout(lay);
-        lay->setContentsMargins(0, 0, 0, 0);
-
-        auto* edit = new QComboBox;
-        edit->addItems(GenericCalculatorExecNode::classIdents());
-        edit->setStyleSheet(gt::gui::stylesheet::comboBox());
-        lay->addWidget(edit);
-
-        auto* model = exec::nodeDataInterface(*node);
-        GtObject* scope = model ? model->scope() : static_cast<GtObject*>(gtApp->currentProject());
-        assert(scope);
-
-        auto* view = new GtPropertyTreeView(scope);
-        view->setAnimated(false);
-        lay->addWidget(view);
-
-        auto updateView = [this, view, node](){
-            view->setObject(nullptr);
-
-            auto obj = node->currentObject();
-            if (obj)
-            {
-                view->setObject(obj);
-                // collapse first category
-                view->collapse(view->model()->index(0, 0, view->rootIndex()));
-
-                QObject::connect(obj, qOverload<GtObject*, GtAbstractProperty*>(&GtObject::dataChanged),
-                                 node, &GenericCalculatorExecNode::onCurrentObjectDataChanged,
-                                 Qt::UniqueConnection);
-            }
-        };
-
-        auto const updateClass = [node, edit](){
-            node->setClassName(GenericCalculatorExecNode::classNameFromIdent(edit->currentText()));
-        };
-        auto const updateClassText = [node, edit](){
-            edit->setCurrentText(GenericCalculatorExecNode::identFromClassName(node->className()));
-        };
-
-        QObject::connect(edit, &QComboBox::currentTextChanged,
-                         edit, updateClass);
-        QObject::connect(node, &GenericCalculatorExecNode::classNameChanged,
-                         edit, updateClassText);
-        QObject::connect(node, &GenericCalculatorExecNode::currentObjectChanged,
-                         view, updateView);
-
-        node->syncConnectedPorts();
-
-        node->className().isEmpty() ? updateClass() : updateClassText();
-        updateView();
-
-        return convertToGraphicsWidget(std::move(w), object);
-    };
+    return &GenericCalculatorExecNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/genericcalculatorexecnodeui.h
+++ b/src/intelli/gui/ui/node/genericcalculatorexecnodeui.h
@@ -9,9 +9,39 @@
 #define GT_INTELLI_GENERICCALCULATOREXECNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <QWidget>
+
+class GtPropertyTreeView;
+class QComboBox;
 
 namespace intelli
 {
+
+class GenericCalculatorExecNode;
+class NodeGraphicsObject;
+
+class GenericCalculatorExecNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit GenericCalculatorExecNodeWidget(GenericCalculatorExecNode& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateCurrentObjectView();
+    void updateClassFromEditor(QString const& classText);
+    void updateClassEditorFromNode(QString const& className);
+
+private:
+
+    GenericCalculatorExecNode* m_node{};
+    QComboBox* m_classEdit{};
+    GtPropertyTreeView* m_view{};
+};
 
 class GenericCalculatorExecNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/logicnodeui.cpp
+++ b/src/intelli/gui/ui/node/logicnodeui.cpp
@@ -10,7 +10,6 @@
 #include <intelli/gui/ui/node/logicnodeui.h>
 #include <intelli/gui/graphics/nodeobject.h>
 #include <intelli/gui/style.h>
-#include <intelli/gui/utilities.h>
 #include <intelli/node/binarydisplay.h>
 #include <intelli/node/logicoperation.h>
 
@@ -21,6 +20,7 @@
 #include <QGraphicsWidget>
 #include <QLCDNumber>
 #include <QLayout>
+#include <QVBoxLayout>
 
 #include <cmath>
 
@@ -333,6 +333,82 @@ LogicNodePainter::drawPort(QPainter& painter,
     }
 }
 
+BinaryDisplayNodeWidget::BinaryDisplayNodeWidget(BinaryDisplayNode& node, QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+
+    m_display = new QLCDNumber(this);
+    lay->addWidget(m_display);
+
+    setMinimumSize(60, 80);
+
+    QObject::connect(m_node, &Node::evaluated,
+                     this, &BinaryDisplayNodeWidget::updateDisplay);
+    QObject::connect(m_node, &Node::portInserted,
+                     this, &BinaryDisplayNodeWidget::updateDigitCount);
+    QObject::connect(m_node, &Node::portDeleted,
+                     this, &BinaryDisplayNodeWidget::updateDigitCount);
+    QObject::connect(gtApp, &GtApplication::themeChanged,
+                     this, &BinaryDisplayNodeWidget::updateStyle);
+
+    updateDisplay();
+    updateDigitCount();
+    updateStyle(gtApp->inDarkMode());
+}
+
+NodeUI::QGraphicsWidgetPtr
+BinaryDisplayNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<BinaryDisplayNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<BinaryDisplayNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+BinaryDisplayNodeWidget::updateDisplay()
+{
+    m_display->display(static_cast<int>(m_node->inputValue()));
+}
+
+void
+BinaryDisplayNodeWidget::updateDigitCount()
+{
+    size_t maxValue = std::pow(2u, m_node->ports(PortType::In).size());
+    int digits = std::ceil(std::log10(maxValue));
+    m_display->setDigitCount(digits);
+    m_display->setMinimumSize(20 * digits, 20);
+}
+
+void
+BinaryDisplayNodeWidget::updateStyle(bool isDark)
+{
+    m_display->setStyleSheet(isDark ?
+       // dark mode
+       R"(QLCDNumber{
+            background-color: rgb(0, 0, 0);
+            border: 2px solid rgb(113, 113, 113);
+            border-width: 2px;
+            border-radius: 10px;
+            color: rgb(255, 255, 255);
+        })"
+       :
+       // bright mode
+       R"(QLCDNumber{
+            background-color: rgb(255, 255, 255);
+            border: 2px solid rgb(113, 113, 113);
+            border-width: 2px;
+            border-radius: 10px;
+            color: rgb(0, 0, 0);
+        })"
+    );
+}
+
 LogicNodeUI::LogicNodeUI() = default;
 
 std::unique_ptr<intelli::NodePainter>
@@ -364,60 +440,5 @@ LogicNodeUI::centralWidgetFactory(Node const& node) const
 {
     if (!qobject_cast<BinaryDisplayNode const*>(&node)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<BinaryDisplayNode*>(&source);
-        if (!node) return nullptr;
-
-        auto b = utils::makeWidgetWithLayout();
-        auto* lay = b->layout();
-
-        auto* wid = new QLCDNumber();
-        lay->addWidget(wid);
-
-        b->setMinimumSize(60, 80);
-
-        auto const updateStyle = [wid](bool isDark){
-            wid->setStyleSheet(isDark ?
-               // dark mode
-               R"(QLCDNumber{
-                    background-color: rgb(0, 0, 0);
-                    border: 2px solid rgb(113, 113, 113);
-                    border-width: 2px;
-                    border-radius: 10px;
-                    color: rgb(255, 255, 255);
-                })"
-               :
-               // bright mode
-               R"(QLCDNumber{
-                    background-color: rgb(255, 255, 255);
-                    border: 2px solid rgb(113, 113, 113);
-                    border-width: 2px;
-                    border-radius: 10px;
-                    color: rgb(0, 0, 0);
-                })"
-            );
-        };
-
-        auto updateDisplay = [wid, node](){
-            int value = node->inputValue();
-            wid->display(value);
-        };
-        auto updateDigitCount = [wid, node](){
-            size_t maxValue = std::pow(2u, node->ports(PortType::In).size());
-            int digits = std::ceil(std::log10(maxValue));
-            wid->setDigitCount(digits);
-            wid->setMinimumSize(20 * digits, 20);
-        };
-
-        QObject::connect(node, &Node::evaluated, wid, updateDisplay);
-        QObject::connect(node, &Node::portInserted, wid, updateDigitCount);
-        QObject::connect(node, &Node::portDeleted, wid, updateDigitCount);
-        QObject::connect(gtApp, &GtApplication::themeChanged, wid, updateStyle);
-
-        updateDisplay();
-        updateDigitCount();
-        updateStyle(gtApp->inDarkMode());
-
-        return convertToGraphicsWidget(std::move(b), object);
-    };
+    return &BinaryDisplayNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/logicnodeui.cpp
+++ b/src/intelli/gui/ui/node/logicnodeui.cpp
@@ -364,7 +364,7 @@ LogicNodeUI::centralWidgetFactory(Node const& node) const
 {
     if (!qobject_cast<BinaryDisplayNode const*>(&node)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<BinaryDisplayNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/logicnodeui.h
+++ b/src/intelli/gui/ui/node/logicnodeui.h
@@ -13,11 +13,16 @@
 #include <intelli/gui/nodeui.h>
 #include <intelli/gui/nodepainter.h>
 #include <intelli/gui/nodegeometry.h>
+#include <QWidget>
+
+class QLCDNumber;
 
 namespace intelli
 {
 
 class LogicNode;
+class BinaryDisplayNode;
+class NodeGraphicsObject;
 /**
  * @brief The LogicNodeUI class.
  * Geometry class for the `LogicNode`. Describes the shape of the Gates shapes
@@ -73,6 +78,28 @@ public:
                   PortType type,
                   PortIndex idx,
                   uint flags) const override;
+};
+
+class BinaryDisplayNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit BinaryDisplayNodeWidget(BinaryDisplayNode& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateDisplay();
+    void updateDigitCount();
+    void updateStyle(bool isDark);
+
+private:
+
+    BinaryDisplayNode* m_node{};
+    QLCDNumber* m_display{};
 };
 
 /**

--- a/src/intelli/gui/ui/node/numberdisplaynodeui.cpp
+++ b/src/intelli/gui/ui/node/numberdisplaynodeui.cpp
@@ -23,7 +23,7 @@ NumberDisplayNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<NumberDisplayNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<NumberDisplayNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/numbermathnodeui.cpp
+++ b/src/intelli/gui/ui/node/numbermathnodeui.cpp
@@ -8,14 +8,86 @@
 #include <intelli/gui/ui/node/numbermathnodeui.h>
 
 #include <intelli/gui/graphics/nodeobject.h>
-#include <intelli/gui/utilities.h>
 #include <intelli/node/numbermath.h>
 
 #include <QComboBox>
 #include <QGraphicsWidget>
-#include <QLayout>
+#include <QVBoxLayout>
 
 using namespace intelli;
+
+NumberMathNodeWidget::NumberMathNodeWidget(NumberMathNode& node, QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+
+    m_combo = new QComboBox(this);
+    lay->addWidget(m_combo);
+    m_combo->addItems(QStringList{"+", "-", "*", "/", "pow"});
+
+    QObject::connect(m_node, &NumberMathNode::operationChanged,
+                     this, &NumberMathNodeWidget::updateComboFromNode);
+    QObject::connect(m_combo, &QComboBox::currentTextChanged,
+                     this, &NumberMathNodeWidget::updateNodeFromCombo);
+
+    updateComboFromNode();
+}
+
+NodeUI::QGraphicsWidgetPtr
+NumberMathNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<NumberMathNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<NumberMathNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+QString
+NumberMathNodeWidget::toText(NumberMathNode::MathOperation op)
+{
+    switch (op)
+    {
+    case NumberMathNode::Minus:
+        return QStringLiteral("-");
+    case NumberMathNode::Divide:
+        return QStringLiteral("/");
+    case NumberMathNode::Multiply:
+        return QStringLiteral("*");
+    case NumberMathNode::Power:
+        return QStringLiteral("pow");
+    case NumberMathNode::Plus:
+        break;
+    }
+    return QStringLiteral("+");
+}
+
+NumberMathNode::MathOperation
+NumberMathNodeWidget::fromText(QString const& text)
+{
+    if (text == QStringLiteral("-")) return NumberMathNode::Minus;
+    if (text == QStringLiteral("*")) return NumberMathNode::Multiply;
+    if (text == QStringLiteral("/")) return NumberMathNode::Divide;
+    if (text == QStringLiteral("pow")) return NumberMathNode::Power;
+    return NumberMathNode::Plus;
+}
+
+void
+NumberMathNodeWidget::updateComboFromNode()
+{
+    m_combo->setCurrentText(toText(m_node->operation()));
+}
+
+void
+NumberMathNodeWidget::updateNodeFromCombo(QString const& text)
+{
+    auto next = fromText(text);
+    if (next == m_node->operation()) return;
+    m_node->setOperation(next);
+}
 
 NumberMathNodeUI::NumberMathNodeUI() = default;
 
@@ -24,56 +96,5 @@ NumberMathNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<NumberMathNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<NumberMathNode*>(&source);
-        if (!node) return nullptr;
-
-        auto base = utils::makeWidgetWithLayout();
-        auto* combo = new QComboBox();
-        base->layout()->addWidget(combo);
-        combo->addItems(QStringList{"+", "-", "*", "/", "pow"});
-
-        auto const toText = [](NumberMathNode::MathOperation op) {
-            switch (op)
-            {
-            case NumberMathNode::Minus:
-                return QStringLiteral("-");
-            case NumberMathNode::Divide:
-                return QStringLiteral("/");
-            case NumberMathNode::Multiply:
-                return QStringLiteral("*");
-            case NumberMathNode::Power:
-                return QStringLiteral("pow");
-            case NumberMathNode::Plus:
-                break;
-            }
-            return QStringLiteral("+");
-        };
-
-        auto const fromText = [](QString const& text) {
-            if (text == QStringLiteral("-")) return NumberMathNode::Minus;
-            if (text == QStringLiteral("*")) return NumberMathNode::Multiply;
-            if (text == QStringLiteral("/")) return NumberMathNode::Divide;
-            if (text == QStringLiteral("pow")) return NumberMathNode::Power;
-            return NumberMathNode::Plus;
-        };
-
-        auto const update = [node, combo, toText]() {
-            combo->setCurrentText(toText(node->operation()));
-        };
-
-        QObject::connect(node, &NumberMathNode::operationChanged,
-                         combo, update);
-
-        QObject::connect(combo, &QComboBox::currentTextChanged,
-                         combo, [node, fromText](QString const& text) {
-            auto next = fromText(text);
-            if (next == node->operation()) return;
-            node->setOperation(next);
-        });
-
-        update();
-
-        return convertToGraphicsWidget(std::move(base), object);
-    };
+    return &NumberMathNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/numbermathnodeui.cpp
+++ b/src/intelli/gui/ui/node/numbermathnodeui.cpp
@@ -24,7 +24,7 @@ NumberMathNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<NumberMathNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<NumberMathNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/numbermathnodeui.h
+++ b/src/intelli/gui/ui/node/numbermathnodeui.h
@@ -9,9 +9,40 @@
 #define GT_INTELLI_NUMBERMATHNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <intelli/node/numbermath.h>
+#include <QWidget>
+
+class QComboBox;
 
 namespace intelli
 {
+
+class NumberMathNode;
+class NodeGraphicsObject;
+
+class NumberMathNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit NumberMathNodeWidget(NumberMathNode& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateComboFromNode();
+    void updateNodeFromCombo(QString const& text);
+
+private:
+
+    static QString toText(NumberMathNode::MathOperation op);
+    static NumberMathNode::MathOperation fromText(QString const& text);
+
+    NumberMathNode* m_node{};
+    QComboBox* m_combo{};
+};
 
 class NumberMathNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/objectinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/objectinputnodeui.cpp
@@ -24,7 +24,7 @@ ObjectInputNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<ObjectInputNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<ObjectInputNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/objectinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/objectinputnodeui.cpp
@@ -14,8 +14,54 @@
 #include <gt_propertyobjectlinkeditor.h>
 
 #include <QGraphicsWidget>
+#include <QVBoxLayout>
 
 using namespace intelli;
+
+ObjectInputNodeWidget::ObjectInputNodeWidget(ObjectInputNode& node, QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+
+    m_editor = new GtPropertyObjectLinkEditor(this);
+    lay->addWidget(m_editor);
+
+    m_editor->setObjectLinkProperty(&m_node->objectProperty());
+
+    QObject::connect(m_node, &Node::evaluated,
+                     this, &ObjectInputNodeWidget::updateScope);
+    QObject::connect(m_node, &Node::evaluated,
+                     this, &ObjectInputNodeWidget::updateText);
+
+    updateScope();
+    updateText();
+}
+
+NodeUI::QGraphicsWidgetPtr
+ObjectInputNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<ObjectInputNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<ObjectInputNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+ObjectInputNodeWidget::updateScope()
+{
+    auto* model = exec::nodeDataInterface(*m_node);
+    m_editor->setScope(model ? model->scope() : m_node->objectProperty().object());
+}
+
+void
+ObjectInputNodeWidget::updateText()
+{
+    m_editor->updateText();
+}
 
 ObjectInputNodeUI::ObjectInputNodeUI() = default;
 
@@ -24,27 +70,5 @@ ObjectInputNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<ObjectInputNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<ObjectInputNode*>(&source);
-        if (!node) return nullptr;
-
-        auto w = std::make_unique<GtPropertyObjectLinkEditor>();
-        w->setObjectLinkProperty(&node->objectProperty());
-
-        auto updateScope = [node, w_ = w.get()]() {
-            auto* model = exec::nodeDataInterface(*node);
-            w_->setScope(model ? model->scope() : node->objectProperty().object());
-        };
-        auto updateText = [w_ = w.get()]() {
-            w_->updateText();
-        };
-
-        QObject::connect(node, &Node::evaluated, w.get(), updateScope);
-        QObject::connect(node, &Node::evaluated, w.get(), updateText);
-
-        updateScope();
-        updateText();
-
-        return convertToGraphicsWidget(std::move(w), object);
-    };
+    return &ObjectInputNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/objectinputnodeui.h
+++ b/src/intelli/gui/ui/node/objectinputnodeui.h
@@ -9,9 +9,36 @@
 #define GT_INTELLI_OBJECTINPUTNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <QWidget>
+
+class GtPropertyObjectLinkEditor;
 
 namespace intelli
 {
+
+class ObjectInputNode;
+class NodeGraphicsObject;
+
+class ObjectInputNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit ObjectInputNodeWidget(ObjectInputNode& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateScope();
+    void updateText();
+
+private:
+
+    ObjectInputNode* m_node{};
+    GtPropertyObjectLinkEditor* m_editor{};
+};
 
 class ObjectInputNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/objectsinknodeui.cpp
+++ b/src/intelli/gui/ui/node/objectsinknodeui.cpp
@@ -12,8 +12,50 @@
 
 #include <QGraphicsWidget>
 #include <QPushButton>
+#include <QVBoxLayout>
 
 using namespace intelli;
+
+ObjectSinkNodeWidget::ObjectSinkNodeWidget(ObjectSink& node, QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+
+    m_button = new QPushButton(QObject::tr("Export"), this);
+    lay->addWidget(m_button);
+
+    m_button->setEnabled(m_node->canExport());
+
+    QObject::connect(m_node, &ObjectSink::exportEnabledChanged,
+                     this, &ObjectSinkNodeWidget::updateExportEnabled);
+    QObject::connect(m_button, &QPushButton::clicked,
+                     this, &ObjectSinkNodeWidget::exportObject);
+}
+
+NodeUI::QGraphicsWidgetPtr
+ObjectSinkNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<ObjectSink*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<ObjectSinkNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+ObjectSinkNodeWidget::updateExportEnabled(bool enabled)
+{
+    m_button->setEnabled(enabled);
+}
+
+void
+ObjectSinkNodeWidget::exportObject()
+{
+    m_node->exportObject();
+}
 
 ObjectSinkNodeUI::ObjectSinkNodeUI() = default;
 
@@ -22,21 +64,5 @@ ObjectSinkNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<ObjectSink const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<ObjectSink*>(&source);
-        if (!node) return nullptr;
-
-        auto w = std::make_unique<QPushButton>(QObject::tr("Export"));
-        w->setEnabled(node->canExport());
-
-        QObject::connect(node, &ObjectSink::exportEnabledChanged,
-                         w.get(), [w_ = w.get()](bool enabled) {
-            w_->setEnabled(enabled);
-        });
-
-        QObject::connect(w.get(), &QPushButton::clicked,
-                         w.get(), [node]() { node->exportObject(); });
-
-        return convertToGraphicsWidget(std::move(w), object);
-    };
+    return &ObjectSinkNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/objectsinknodeui.cpp
+++ b/src/intelli/gui/ui/node/objectsinknodeui.cpp
@@ -22,7 +22,7 @@ ObjectSinkNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<ObjectSink const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<ObjectSink*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/objectsinknodeui.h
+++ b/src/intelli/gui/ui/node/objectsinknodeui.h
@@ -9,9 +9,36 @@
 #define GT_INTELLI_OBJECTSINKNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <QWidget>
+
+class QPushButton;
 
 namespace intelli
 {
+
+class ObjectSink;
+class NodeGraphicsObject;
+
+class ObjectSinkNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit ObjectSinkNodeWidget(ObjectSink& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateExportEnabled(bool enabled);
+    void exportObject();
+
+private:
+
+    ObjectSink* m_node{};
+    QPushButton* m_button{};
+};
 
 class ObjectSinkNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/sleepynodeui.cpp
+++ b/src/intelli/gui/ui/node/sleepynodeui.cpp
@@ -24,7 +24,7 @@ SleepyNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<SleepyNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<SleepyNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/stringbuildernodeui.cpp
+++ b/src/intelli/gui/ui/node/stringbuildernodeui.cpp
@@ -25,7 +25,7 @@ StringBuilderNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<StringBuilderNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<StringBuilderNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/stringbuildernodeui.cpp
+++ b/src/intelli/gui/ui/node/stringbuildernodeui.cpp
@@ -8,15 +8,62 @@
 #include <intelli/gui/ui/node/stringbuildernodeui.h>
 
 #include <intelli/gui/graphics/nodeobject.h>
-#include <intelli/gui/utilities.h>
 #include <intelli/node/stringbuilder.h>
 
 #include <gt_lineedit.h>
 
 #include <QGraphicsWidget>
-#include <QLayout>
+#include <QVBoxLayout>
 
 using namespace intelli;
+
+StringBuilderNodeWidget::StringBuilderNodeWidget(StringBuilderNode& node, QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+
+    m_edit = new GtLineEdit(this);
+    m_edit->setPlaceholderText(QStringLiteral("%1/%2"));
+    m_edit->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_edit->setMinimumWidth(50);
+    lay->addWidget(m_edit);
+
+    QObject::connect(m_edit, &GtLineEdit::focusOut,
+                     this, &StringBuilderNodeWidget::updateNodeFromPattern);
+    QObject::connect(m_edit, &GtLineEdit::clearFocusOut,
+                     this, &StringBuilderNodeWidget::updateNodeFromPattern);
+    QObject::connect(m_node, &StringBuilderNode::patternChanged,
+                     this, &StringBuilderNodeWidget::updatePatternFromNode);
+
+    updatePatternFromNode();
+}
+
+NodeUI::QGraphicsWidgetPtr
+StringBuilderNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<StringBuilderNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<StringBuilderNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+StringBuilderNodeWidget::updatePatternFromNode()
+{
+    QString const& text = m_node->pattern();
+    if (m_edit->text() != text) m_edit->setText(text);
+}
+
+void
+StringBuilderNodeWidget::updateNodeFromPattern()
+{
+    QString const& text = m_edit->text();
+    if (m_node->pattern() != text) m_node->setPattern(text);
+}
 
 StringBuilderNodeUI::StringBuilderNodeUI() = default;
 
@@ -25,34 +72,5 @@ StringBuilderNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<StringBuilderNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<StringBuilderNode*>(&source);
-        if (!node) return nullptr;
-
-        auto base = utils::makeWidgetWithLayout();
-        auto* lay = base->layout();
-
-        auto* edit = new GtLineEdit();
-        edit->setPlaceholderText(QStringLiteral("%1/%2"));
-        edit->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-        edit->setMinimumWidth(50);
-        lay->addWidget(edit);
-
-        auto const updatePattern = [node, edit]() {
-            QString const& text = edit->text();
-            if (node->pattern() != text) node->setPattern(text);
-        };
-        auto const updateText = [node, edit]() {
-            QString const& text = node->pattern();
-            if (edit->text() != text) edit->setText(text);
-        };
-
-        QObject::connect(edit, &GtLineEdit::focusOut, edit, updatePattern);
-        QObject::connect(edit, &GtLineEdit::clearFocusOut, edit, updatePattern);
-        QObject::connect(node, &StringBuilderNode::patternChanged, edit, updateText);
-
-        updateText();
-
-        return convertToGraphicsWidget(std::move(base), object);
-    };
+    return &StringBuilderNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/stringbuildernodeui.h
+++ b/src/intelli/gui/ui/node/stringbuildernodeui.h
@@ -9,9 +9,36 @@
 #define GT_INTELLI_STRINGBUILDERNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <QWidget>
+
+class GtLineEdit;
 
 namespace intelli
 {
+
+class StringBuilderNode;
+class NodeGraphicsObject;
+
+class StringBuilderNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit StringBuilderNodeWidget(StringBuilderNode& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updatePatternFromNode();
+    void updateNodeFromPattern();
+
+private:
+
+    StringBuilderNode* m_node{};
+    GtLineEdit* m_edit{};
+};
 
 class StringBuilderNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/stringinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/stringinputnodeui.cpp
@@ -13,8 +13,55 @@
 #include <gt_lineedit.h>
 
 #include <QGraphicsWidget>
+#include <QVBoxLayout>
 
 using namespace intelli;
+
+StringInputNodeWidget::StringInputNodeWidget(StringInputNode& node, QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+
+    m_edit = new GtLineEdit(this);
+    m_edit->setPlaceholderText(QStringLiteral("String"));
+    m_edit->setMinimumWidth(50);
+    m_edit->resize(100, m_edit->sizeHint().height());
+    lay->addWidget(m_edit);
+
+    QObject::connect(m_edit, &GtLineEdit::focusOut,
+                     this, &StringInputNodeWidget::updateNodeFromText);
+    QObject::connect(m_edit, &GtLineEdit::clearFocusOut,
+                     this, &StringInputNodeWidget::updateNodeFromText);
+    QObject::connect(m_node, &StringInputNode::valueChanged,
+                     this, &StringInputNodeWidget::updateTextFromNode);
+
+    updateTextFromNode();
+}
+
+NodeUI::QGraphicsWidgetPtr
+StringInputNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<StringInputNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<StringInputNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+StringInputNodeWidget::updateNodeFromText()
+{
+    if (m_node->value() != m_edit->text()) m_node->setValue(m_edit->text());
+}
+
+void
+StringInputNodeWidget::updateTextFromNode()
+{
+    if (m_edit->text() != m_node->value()) m_edit->setText(m_node->value());
+}
 
 StringInputNodeUI::StringInputNodeUI() = default;
 
@@ -23,28 +70,5 @@ StringInputNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<StringInputNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<StringInputNode*>(&source);
-        if (!node) return nullptr;
-
-        auto w = std::make_unique<GtLineEdit>();
-        w->setPlaceholderText(QStringLiteral("String"));
-        w->setMinimumWidth(50);
-        w->resize(100, w->sizeHint().height());
-
-        auto const updateProp = [node, w_ = w.get()]() {
-            if (node->value() != w_->text()) node->setValue(w_->text());
-        };
-        auto const updateText = [node, w_ = w.get()]() {
-            if (w_->text() != node->value()) w_->setText(node->value());
-        };
-
-        QObject::connect(w.get(), &GtLineEdit::focusOut, w.get(), updateProp);
-        QObject::connect(w.get(), &GtLineEdit::clearFocusOut, w.get(), updateProp);
-        QObject::connect(node, &StringInputNode::valueChanged, w.get(), updateText);
-
-        updateText();
-
-        return convertToGraphicsWidget(std::move(w), object);
-    };
+    return &StringInputNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/stringinputnodeui.cpp
+++ b/src/intelli/gui/ui/node/stringinputnodeui.cpp
@@ -23,7 +23,7 @@ StringInputNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<StringInputNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<StringInputNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/stringinputnodeui.h
+++ b/src/intelli/gui/ui/node/stringinputnodeui.h
@@ -9,9 +9,36 @@
 #define GT_INTELLI_STRINGINPUTNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <QWidget>
+
+class GtLineEdit;
 
 namespace intelli
 {
+
+class StringInputNode;
+class NodeGraphicsObject;
+
+class StringInputNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit StringInputNodeWidget(StringInputNode& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateNodeFromText();
+    void updateTextFromNode();
+
+private:
+
+    StringInputNode* m_node{};
+    GtLineEdit* m_edit{};
+};
 
 class StringInputNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/stringselectionnodeui.cpp
+++ b/src/intelli/gui/ui/node/stringselectionnodeui.cpp
@@ -11,10 +11,64 @@
 #include <intelli/node/stringselection.h>
 #include <intelli/nodedatainterface.h>
 
-#include <QComboBox>
 #include <QGraphicsWidget>
 
 using namespace intelli;
+
+StringSelectionNodeWidget::StringSelectionNodeWidget(StringSelectionNode& node) :
+    QComboBox()
+{
+    m_node = &node;
+
+    QObject::connect(m_node, &StringSelectionNode::optionsChanged,
+                     this, &StringSelectionNodeWidget::updateOptionsFromNode);
+    QObject::connect(m_node, &StringSelectionNode::selectionChanged,
+                     this, &StringSelectionNodeWidget::updateSelectionFromNode);
+    QObject::connect(this, &QComboBox::currentTextChanged,
+                     this, &StringSelectionNodeWidget::updateNodeFromSelection);
+
+    if (exec::nodeDataInterface(*m_node))
+    {
+        updateOptionsFromNode();
+    }
+    updateSelectionFromNode();
+}
+
+NodeUI::QGraphicsWidgetPtr
+StringSelectionNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<StringSelectionNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<StringSelectionNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+StringSelectionNodeWidget::updateOptionsFromNode()
+{
+    clear();
+    addItems(m_node->options());
+}
+
+void
+StringSelectionNodeWidget::updateSelectionFromNode()
+{
+    auto const selection = m_node->selection();
+    if (selection.isEmpty())
+    {
+        setCurrentIndex(-1);
+        return;
+    }
+
+    if (currentText() != selection) setCurrentText(selection);
+}
+
+void
+StringSelectionNodeWidget::updateNodeFromSelection(QString const& text)
+{
+    m_node->setSelection(text);
+}
 
 StringSelectionNodeUI::StringSelectionNodeUI() = default;
 
@@ -23,40 +77,5 @@ StringSelectionNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<StringSelectionNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<StringSelectionNode*>(&source);
-        if (!node) return nullptr;
-
-        auto w = std::make_unique<QComboBox>();
-
-        auto const updateOptions = [w_ = w.get()](QStringList const& options) {
-            w_->clear();
-            w_->addItems(options);
-        };
-        auto const updateSelection = [w_ = w.get()](QString const& selection) {
-            if (selection.isEmpty())
-            {
-                w_->setCurrentIndex(-1);
-                return;
-            }
-            if (w_->currentText() != selection) w_->setCurrentText(selection);
-        };
-
-        QObject::connect(node, &StringSelectionNode::optionsChanged,
-                         w.get(), updateOptions);
-        QObject::connect(node, &StringSelectionNode::selectionChanged,
-                         w.get(), updateSelection);
-        QObject::connect(w.get(), &QComboBox::currentTextChanged,
-                         w.get(), [node](QString const& text) {
-            node->setSelection(text);
-        });
-
-        if (exec::nodeDataInterface(*node))
-        {
-            updateOptions(node->options());
-        }
-        updateSelection(node->selection());
-
-        return convertToGraphicsWidget(std::move(w), object);
-    };
+    return &StringSelectionNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/stringselectionnodeui.cpp
+++ b/src/intelli/gui/ui/node/stringselectionnodeui.cpp
@@ -23,7 +23,7 @@ StringSelectionNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<StringSelectionNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<StringSelectionNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/stringselectionnodeui.h
+++ b/src/intelli/gui/ui/node/stringselectionnodeui.h
@@ -9,9 +9,34 @@
 #define GT_INTELLI_STRINGSELECTIONNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <QComboBox>
 
 namespace intelli
 {
+
+class StringSelectionNode;
+class NodeGraphicsObject;
+
+class StringSelectionNodeWidget : public QComboBox
+{
+    Q_OBJECT
+
+public:
+
+    explicit StringSelectionNodeWidget(StringSelectionNode& node);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateOptionsFromNode();
+    void updateSelectionFromNode();
+    void updateNodeFromSelection(QString const& text);
+
+private:
+
+    StringSelectionNode* m_node{};
+};
 
 class StringSelectionNodeUI : public NodeUI
 {

--- a/src/intelli/gui/ui/node/textdisplaynodeui.cpp
+++ b/src/intelli/gui/ui/node/textdisplaynodeui.cpp
@@ -8,7 +8,6 @@
 #include <intelli/gui/ui/node/textdisplaynodeui.h>
 
 #include <intelli/gui/graphics/nodeobject.h>
-#include <intelli/gui/utilities.h>
 #include <intelli/node/textdisplay.h>
 
 #include <gt_application.h>
@@ -18,13 +17,82 @@
 #include <gt_xmlhighlighter.h>
 
 #include <QGraphicsWidget>
-#include <QLayout>
 #include <QSyntaxHighlighter>
 #include <QTextDocument>
+#include <QVBoxLayout>
 
 #include <cassert>
 
 using namespace intelli;
+
+TextDisplayNodeWidget::TextDisplayNodeWidget(TextDisplayNode& node, QWidget* parent) :
+    QWidget(parent)
+{
+    m_node = &node;
+
+    auto* lay = new QVBoxLayout(this);
+    lay->setContentsMargins(0, 0, 0, 0);
+
+    m_editor = new GtCodeEditor(this);
+    lay->addWidget(m_editor);
+
+    m_editor->setMinimumSize(125, 25);
+    m_editor->resize(400, 200);
+    m_editor->setReadOnly(true);
+
+    QObject::connect(m_node, &Node::inputDataRecieved,
+                     this, &TextDisplayNodeWidget::updateTextFromNode);
+    QObject::connect(m_node,
+                     qOverload<GtObject*, GtAbstractProperty*>(&Node::dataChanged),
+                     this,
+                     &TextDisplayNodeWidget::updateHighlighterFromNode);
+    QObject::connect(gtApp, &GtApplication::themeChanged,
+                     this, &TextDisplayNodeWidget::updateHighlighterFromNode);
+
+    updateTextFromNode();
+    updateHighlighterFromNode();
+}
+
+NodeUI::QGraphicsWidgetPtr
+TextDisplayNodeWidget::create(Node& source, NodeGraphicsObject& object)
+{
+    auto* node = qobject_cast<TextDisplayNode*>(&source);
+    if (!node) return nullptr;
+
+    auto w = std::make_unique<TextDisplayNodeWidget>(*node);
+    return NodeUI::convertToGraphicsWidget(std::move(w), object);
+}
+
+void
+TextDisplayNodeWidget::updateTextFromNode()
+{
+    m_editor->setPlainText(m_node->displayText());
+}
+
+void
+TextDisplayNodeWidget::updateHighlighterFromNode()
+{
+    auto* document = m_editor->document();
+    assert(document);
+
+    auto* highlighter = document->findChild<QSyntaxHighlighter*>();
+    if (highlighter) highlighter->deleteLater();
+
+    switch (m_node->textType())
+    {
+    case TextDisplayNode::TextType::PlainText:
+        break;
+    case TextDisplayNode::TextType::Xml:
+        new GtXmlHighlighter(document);
+        break;
+    case TextDisplayNode::TextType::Python:
+        new GtPyHighlighter(document);
+        break;
+    case TextDisplayNode::TextType::JavaScript:
+        new GtJsHighlighter(document);
+        break;
+    }
+}
 
 TextDisplayNodeUI::TextDisplayNodeUI() = default;
 
@@ -33,57 +101,5 @@ TextDisplayNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<TextDisplayNode const*>(&n)) return {};
 
-    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
-        auto* node = qobject_cast<TextDisplayNode*>(&source);
-        if (!node) return nullptr;
-
-        auto b = utils::makeWidgetWithLayout();
-        auto* lay = b->layout();
-
-        auto* w = new GtCodeEditor();
-        lay->addWidget(w);
-
-        w->setMinimumSize(125, 25);
-        w->resize(400, 200);
-        w->setReadOnly(true);
-
-        auto const updateHighlighter = [node, w]() {
-            auto* document = w->document();
-            assert(document);
-
-            auto* highlighter = document->findChild<QSyntaxHighlighter*>();
-            if (highlighter) highlighter->deleteLater();
-
-            switch (node->textType())
-            {
-            case TextDisplayNode::TextType::PlainText:
-                break;
-            case TextDisplayNode::TextType::Xml:
-                new GtXmlHighlighter(document);
-                break;
-            case TextDisplayNode::TextType::Python:
-                new GtPyHighlighter(document);
-                break;
-            case TextDisplayNode::TextType::JavaScript:
-                new GtJsHighlighter(document);
-                break;
-            }
-        };
-
-        auto const updateText = [node, w]() {
-            w->setPlainText(node->displayText());
-        };
-
-        QObject::connect(node, &Node::inputDataRecieved, w, updateText);
-        QObject::connect(node,
-                         qOverload<GtObject*, GtAbstractProperty*>(&Node::dataChanged),
-                         w,
-                         updateHighlighter);
-        QObject::connect(gtApp, &GtApplication::themeChanged, w, updateHighlighter);
-
-        updateText();
-        updateHighlighter();
-
-        return convertToGraphicsWidget(std::move(b), object);
-    };
+    return &TextDisplayNodeWidget::create;
 }

--- a/src/intelli/gui/ui/node/textdisplaynodeui.cpp
+++ b/src/intelli/gui/ui/node/textdisplaynodeui.cpp
@@ -33,7 +33,7 @@ TextDisplayNodeUI::centralWidgetFactory(Node const& n) const
 {
     if (!qobject_cast<TextDisplayNode const*>(&n)) return {};
 
-    return [](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
+    return [this](Node& source, NodeGraphicsObject& object) -> QGraphicsWidgetPtr {
         auto* node = qobject_cast<TextDisplayNode*>(&source);
         if (!node) return nullptr;
 

--- a/src/intelli/gui/ui/node/textdisplaynodeui.h
+++ b/src/intelli/gui/ui/node/textdisplaynodeui.h
@@ -9,9 +9,36 @@
 #define GT_INTELLI_TEXTDISPLAYNODEUI_H
 
 #include <intelli/gui/nodeui.h>
+#include <QWidget>
+
+class GtCodeEditor;
 
 namespace intelli
 {
+
+class TextDisplayNode;
+class NodeGraphicsObject;
+
+class TextDisplayNodeWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit TextDisplayNodeWidget(TextDisplayNode& node, QWidget* parent = nullptr);
+
+    static NodeUI::QGraphicsWidgetPtr create(Node& source, NodeGraphicsObject& object);
+
+private slots:
+
+    void updateTextFromNode();
+    void updateHighlighterFromNode();
+
+private:
+
+    TextDisplayNode* m_node{};
+    GtCodeEditor* m_editor{};
+};
 
 class TextDisplayNodeUI : public NodeUI
 {

--- a/src/intelli/node/booldisplay.cpp
+++ b/src/intelli/node/booldisplay.cpp
@@ -9,6 +9,9 @@
 
 #include <intelli/node/booldisplay.h>
 #include <intelli/data/bool.h>
+#include <intelli/gui/widgets/booldisplaygraphicswidget.h>
+
+#include <cassert>
 
 using namespace intelli;
 
@@ -18,6 +21,9 @@ BoolDisplayNode::BoolDisplayNode() :
                   tr("Display Mode"),
                   tr("Display Mode"))
 {
+    using DisplayMode = BoolDisplayGraphicsWidget::DisplayMode;
+
+    m_displayMode.registerEnum<DisplayMode>();
     registerProperty(m_displayMode);
 
     setNodeEvalMode(NodeEvalMode::Blocking);

--- a/src/intelli/node/booldisplay.cpp
+++ b/src/intelli/node/booldisplay.cpp
@@ -23,7 +23,10 @@ BoolDisplayNode::BoolDisplayNode() :
 {
     using DisplayMode = BoolDisplayGraphicsWidget::DisplayMode;
 
-    m_displayMode.registerEnum<DisplayMode>();
+    bool success = m_displayMode.registerEnum<DisplayMode>();
+    assert(success);
+    Q_UNUSED(success);
+
     registerProperty(m_displayMode);
 
     setNodeEvalMode(NodeEvalMode::Blocking);

--- a/src/intelli/node/booldisplay.h
+++ b/src/intelli/node/booldisplay.h
@@ -21,7 +21,7 @@ class BoolDisplayNode : public Node
 {
     Q_OBJECT
 
-    friend class BoolNodeUI;
+    friend class BoolDisplayNodeWidget;
 
 public:
 

--- a/src/intelli/node/input/boolinput.cpp
+++ b/src/intelli/node/input/boolinput.cpp
@@ -9,6 +9,9 @@
 
 #include <intelli/node/input/boolinput.h>
 #include <intelli/data/bool.h>
+#include <intelli/gui/widgets/booldisplaygraphicswidget.h>
+
+#include <cassert>
 
 using namespace intelli;
 
@@ -19,6 +22,11 @@ BoolInputNode::BoolInputNode() :
                   tr("Display Mode"),
                   tr("Display Mode"))
 {
+    using DisplayMode = BoolDisplayGraphicsWidget::DisplayMode;
+
+    bool success = m_displayMode.registerEnum<DisplayMode>();
+    assert(success);
+
     registerProperty(m_value);
     registerProperty(m_displayMode);
 
@@ -42,6 +50,7 @@ BoolInputNode::setValue(bool value)
 {
     m_value = value;
 }
+
 
 void
 BoolInputNode::eval()

--- a/src/intelli/node/input/boolinput.h
+++ b/src/intelli/node/input/boolinput.h
@@ -22,8 +22,7 @@ class GT_INTELLI_EXPORT BoolInputNode : public Node
 {
     Q_OBJECT
 
-    friend class BoolNodeUI;
-
+    friend class BoolInputNodeWidget;
 public:
 
     Q_INVOKABLE BoolInputNode();


### PR DESCRIPTION
## Summary by Sourcery

Refactor various node UIs to use dedicated widget classes instead of inline factory lambdas, improving structure and reusability of the node GUI code.

Enhancements:
- Introduce dedicated QWidget-based classes for multiple node types (file input, bool display/input, calculator exec, directory source, logic binary display, number math, text display, string selection, string builder, string input, object input, and object sink) and wire them into NodeUI factory methods.
- Move Bool display mode enum registration from UI code into BoolDisplayNode and BoolInputNode constructors to better encapsulate property setup within the nodes.
- Adjust existing node UI factories (e.g., number display and sleepy nodes) to use captures compatible with the new widget-based factory pattern without changing behavior.